### PR TITLE
Configurable dev port

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,14 +1,15 @@
 var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 var config = require('./webpack.config');
+var port = process.env.PORT || 3000;
 
 new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath,
   hot: true
-}).listen(3000, 'localhost', function (err, result) {
+}).listen(port, 'localhost', function (err, result) {
   if (err) {
     console.log(err);
   }
 
-  console.log('Listening at localhost:3000');
+  console.log('Listening at localhost:' + port);
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ var webpack = require('webpack');
 var devtool;
 var loaders = ['babel?stage=0'];
 var DEV = process.env.NODE_ENV === 'development';
+var port = process.env.PORT || 3000;
 
 var plugins = [
   new webpack.DefinePlugin({
@@ -26,7 +27,7 @@ if (DEV) {
   ]);
   entry = Object.keys(entry).reduce(function (result, key) {
     result[key] = [
-      'webpack-dev-server/client?http://localhost:3000',
+      'webpack-dev-server/client?http://localhost:' + port,
       'webpack/hot/only-dev-server',
       entry[key]
     ];


### PR DESCRIPTION
Default is 3000, but can be overriden
```bash
16:23 $ npm start

> react-motion@0.0.1 start /Users/nkbt/nkbt/react-animation
> NODE_ENV=development node server.js

Listening at localhost:3000
```


```bash
16:23 $ PORT=3001 npm start

> react-motion@0.0.1 start /Users/nkbt/nkbt/react-animation
> NODE_ENV=development node server.js

Listening at localhost:3001
```