### PR TITLE
Add .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+coverage
+lib
+node_modules
+*/all.js
+webpack.*.js
+server.js

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "start": "NODE_ENV=development node server.js",
     "build": "NODE_ENV=production webpack -p",
-    "lint": "eslint Spring.jsx stepper.js utils.js",
+    "lint": "eslint .",
     "prerelease": "NODE_ENV=production webpack --config webpack.prod.config.js",
     "test": "mocha --compilers js:babel/register --recursive test",
     "test:dev": "npm test -- --watch",


### PR DESCRIPTION
So we can safely process all files (future proof). And it is simply more convenient way to run `eslint .`