### PR TITLE
Added the ability to change the wrapper component from the default "div"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ lib
 
 .DS_Store
 all.js.map
+
+
+# Intellij
+.idea/
+*.iml
+*.iws

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ getEndValues: function(currentPositions) {
 },
 
 ```
-Spring also exposes an optional "component" prop similar to [ReactTransitionGroup](https://facebook.github.io/react/docs/animation.html#rendering-a-different-component) that allows
+Spring also exposes an optional "component" prop, similar to [ReactTransitionGroup](https://facebook.github.io/react/docs/animation.html#rendering-a-different-component), that allows
 you to specify the wrapper component for the rendered children. Defaults to a 'div'.
 
 ```jsx

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Like `Spring`, but can takes two other props: `willEnter` and `willLeave`. Throu
 
 `willLeave`: a callback that's called **many** times and is passed `(keyThatLeaves, correspondingValue, endValueYouJustSpecified, currentInterpolatedValue, currentSpeed)`. Return an object/array configuration (which will serve as the new `endValue[keyThatLeaves]` and merged into `endValue`) to indicate you still want to keep the item around. Otherwise, return `null`.
 
+`component`: (Optional) Same prop as `Spring`, allows for the customization of the wrapper element in the rendered children. Defaults to 'div'
+
 #### Sample Usage
 _(See the demo files for fuller ones.)_
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ let Demo = React.createClass({
 The library exports a default `Spring`, a `TransitionSpring` and `utils`.
 
 ### &lt;Spring />
-Exposes a single prop, `endValue`, which takes either an object, an array or a function that returns an object or an array.
+Exposes a single required prop, `endValue`, which takes either an object, an array or a function that returns an object or an array.
 Type: `endValue: object | array | object -> (object | array)`.
 
 `endValue` can be of an arbitrary shape (**but must stay the same shape from one render to the next**). There are however 2 reserved keys: `val` and `config`. Say your initial data structure looks so:
@@ -181,6 +181,21 @@ getEndValues: function(currentPositions) {
   return {val: endValue, config: [120, 17]};
 },
 
+```
+Spring also exposes an optional "component" prop similar to [ReactTransitionGroup](https://facebook.github.io/react/docs/animation.html#rendering-a-different-component) that allows
+you to specify the wrapper component for the rendered children. Defaults to a 'div'.
+
+```jsx
+<Spring endValue={{size: {val: 10}, top: 20}} component="span">
+  {tweeningCollection => {
+    let style = {
+      width: tweeningCollection.size.val,
+      height: tweeningCollection.size.val,
+      top: tweeningCollection.top,
+    };
+    return <div style={style} />;
+  }}
+</Spring>
 ```
 
 ### &lt;TransitionSpring />

--- a/demo0/Demo.jsx
+++ b/demo0/Demo.jsx
@@ -14,7 +14,7 @@ const Demo = React.createClass({
     return (
       <div>
         <button onMouseDown={this.handleMouseDown}>Toggle</button>
-        <Spring endValue={{val: this.state.open ? 400 : 0}}>
+        <Spring endValue={{val: this.state.open ? 400 : 0}} component="span">
           {({val}) =>
             // children is a callback which should accept the current value of
             // `endValue`

--- a/src/Spring.js
+++ b/src/Spring.js
@@ -149,7 +149,7 @@ export const Spring = React.createClass({
 
   getDefaultProps() {
     return {
-          component: 'div',
+      component: 'div',
     };
   },
   getInitialState() {
@@ -252,6 +252,7 @@ export const TransitionSpring = React.createClass({
       PropTypes.object,
       PropTypes.array,
     ]),
+    component: PropTypes.any,
     children: PropTypes.func.isRequired,
   },
 
@@ -259,6 +260,7 @@ export const TransitionSpring = React.createClass({
     return {
       willEnter: (key, value) => value,
       willLeave: () => null,
+      component: 'div',
     };
   },
 
@@ -385,7 +387,7 @@ export const TransitionSpring = React.createClass({
 
   render() {
     const {currVals} = this.state;
-    return React.Children.only(this.props.children(currVals));
+    return React.createElement(this.props.component, this.props, React.Children.only(this.props.children(currVals)));
   },
 });
 

--- a/src/Spring.js
+++ b/src/Spring.js
@@ -144,8 +144,14 @@ export const Spring = React.createClass({
       PropTypes.array,
     ]).isRequired,
     children: PropTypes.func.isRequired,
+    component: PropTypes.any,
   },
 
+  getDefaultProps() {
+    return {
+          component: 'div',
+    };
+  },
   getInitialState() {
     let {endValue} = this.props;
     if (typeof endValue === 'function') {
@@ -220,7 +226,7 @@ export const Spring = React.createClass({
 
   render() {
     const {currVals} = this.state;
-    return React.Children.only(this.props.children(currVals));
+    return React.createElement(this.props.component, this.props, React.Children.only(this.props.children(currVals)));
   },
 });
 

--- a/test/Spring-test.js
+++ b/test/Spring-test.js
@@ -4,6 +4,47 @@ import React from 'react';
 
 const FRAME_RATE = 1 / 60;
 
+describe('TransitionSpring', ()=> {
+  it('should default to a "div" as a child wrapper component', ()=> {
+    const element = React.createElement(s.TransitionSpring, {endValue: {top: 100}}, () => {
+      return React.createElement('span')
+    });
+    const renderer = React.addons.TestUtils.createRenderer();
+    renderer.render(element);
+    const component = renderer.getRenderOutput();
+    expect(component.type).toEqual("div");
+  });
+  it('should allow a user to modify the containing component', ()=> {
+    const element = React.createElement(s.TransitionSpring, {endValue: {top: 100}, component: 'span'}, () => {
+      return React.createElement('span')
+    });
+    const renderer = React.addons.TestUtils.createRenderer();
+    renderer.render(element);
+    const component = renderer.getRenderOutput();
+    expect(component.type).toEqual("span");
+  });
+});
+describe('Spring', ()=> {
+  it('should default to a "div" as a child wrapper component', ()=> {
+    const element = React.createElement(s.Spring, {endValue: {top: 100}}, () => {
+      return React.createElement('span')
+    });
+    const renderer = React.addons.TestUtils.createRenderer();
+    renderer.render(element);
+    const component = renderer.getRenderOutput();
+    expect(component.type).toEqual("div");
+  });
+  it('should allow a user to modify the containing component', ()=> {
+    const element = React.createElement(s.Spring, {endValue: {top: 100}, component: 'span'}, () => {
+      return React.createElement('span')
+    });
+    const renderer = React.addons.TestUtils.createRenderer();
+    renderer.render(element);
+    const component = renderer.getRenderOutput();
+    expect(component.type).toEqual("span");
+  });
+});
+
 describe('updateCurrVals', () => {
   it('should not error on null', () => {
     expect(s.updateCurrVals(FRAME_RATE, {val: null}, {val: null}, {val: null}))


### PR DESCRIPTION
This PR adds the ability to specify the wrapper component on Spring and TransitionSpring rather than let it default to a DIV. This is very similar to the way the current ReactTransitionGroup works. This will allow ReactMotion to work semantically in more places, as well as work inside Tables without causing invariant violations. I updated the readme to reflect the changes and added unit tests into Spring-test.js. Let me know if this looks okay! Thanks for the awesome work.