### PR TITLE
Replace `forEach` with `reduce` for object creation

### DIFF
--- a/src/Spring.js
+++ b/src/Spring.js
@@ -20,6 +20,11 @@ function zero() {
   return 0;
 }
 
+function assignByObjKey(ret, objWithKey) {
+  ret[objWithKey.key] = objWithKey;
+  return ret;
+}
+
 // TODO: refactor common logic with updateCurrValue and updateCurrVelocity
 function interpolateValue(alpha, nextValue, prevValue) {
   if (nextValue === null) {
@@ -47,11 +52,10 @@ function interpolateValue(alpha, nextValue, prevValue) {
     return nextValue.map((_, i) => interpolateValue(alpha, nextValue[i], prevValue[i]));
   }
   if (isPlainObject(nextValue)) {
-    const ret = {};
-    Object.keys(nextValue).forEach(key => {
+    return Object.keys(nextValue).reduce((ret, key) => {
       ret[key] = interpolateValue(alpha, nextValue[key], prevValue[key]);
-    });
-    return ret;
+      return ret;
+    }, {});
   }
   return nextValue;
 }
@@ -85,11 +89,10 @@ export function updateCurrValue(frameRate, currValue, currVelocity, endValue, k,
     return endValue.map((_, i) => updateCurrValue(frameRate, currValue[i], currVelocity[i], endValue[i], k, b));
   }
   if (isPlainObject(endValue)) {
-    const ret = {};
-    Object.keys(endValue).forEach(key => {
+    return Object.keys(endValue).reduce((ret, key) => {
       ret[key] = updateCurrValue(frameRate, currValue[key], currVelocity[key], endValue[key], k, b);
-    });
-    return ret;
+      return ret;
+    }, {});
   }
   return endValue;
 }
@@ -122,11 +125,10 @@ export function updateCurrVelocity(frameRate, currValue, currVelocity, endValue,
     return endValue.map((_, i) => updateCurrVelocity(frameRate, currValue[i], currVelocity[i], endValue[i], k, b));
   }
   if (isPlainObject(endValue)) {
-    const ret = {};
-    Object.keys(endValue).forEach(key => {
+    return Object.keys(endValue).reduce((ret, key) => {
       ret[key] = updateCurrVelocity(frameRate, currValue[key], currVelocity[key], endValue[key], k, b);
-    });
-    return ret;
+      return ret;
+    }, {});
   }
   return mapTree(zero, currVelocity);
 }
@@ -292,19 +294,9 @@ export const TransitionSpring = React.createClass({
 
     let mergedValue;
     if (Array.isArray(endValue)) {
-      let currValueObj = {};
-      currValue.forEach(objWithKey => {
-        currValueObj[objWithKey.key] = objWithKey;
-      });
-
-      let endValueObj = {};
-      endValue.forEach(objWithKey => {
-        endValueObj[objWithKey.key] = objWithKey;
-      });
-      let currVelocityObj = {};
-      endValue.forEach(objWithKey => {
-        currVelocityObj[objWithKey.key] = objWithKey;
-      });
+      const currValueObj = currValue.reduce(assignByObjKey, {});
+      const endValueObj = endValue.reduce(assignByObjKey, {});
+      const currVelocityObj = endValue.reduce(assignByObjKey, {});
 
       const mergedValueObj = mergeDiff(
         currValueObj,

--- a/src/mapTree.js
+++ b/src/mapTree.js
@@ -17,11 +17,10 @@ function _mapTree(path, f, trees) {
     return t1.map((_, i) => _mapTree([...path, i], f, trees.map(val => val[i])));
   }
   if (isPlainObject(t1)) {
-    const newTree = {};
-    Object.keys(t1).forEach(key => {
+    return Object.keys(t1).reduce((newTree, key) => {
       newTree[key] = _mapTree([...path, key], f, trees.map(val => val[key]));
-    });
-    return newTree;
+      return newTree;
+    }, {});
   }
   // return last one just because
   return trees[trees.length - 1];

--- a/src/reorderKeys.js
+++ b/src/reorderKeys.js
@@ -1,7 +1,6 @@
 export default function reorderKeys(obj, f) {
-  const ret = {};
-  f(Object.keys(obj)).forEach(key => {
+  return f(Object.keys(obj)).reduce((ret, key) => {
     ret[key] = obj[key];
-  });
-  return ret;
+    return ret;
+  }, {});
 }


### PR DESCRIPTION
This is more for stylistic and purity reasons, but here is a completely-unscientific performance explanation:

To handle `let`/`const` block scoping, Babel (loose mode) compiles this:

```js
function interpolateValue(alpha, nextValue, prevValue) {
  /* ... */
  if (nextValue.val != null) {
    let ret = {
      val: interpolateValue(alpha, nextValue.val, prevValue.val),
    };
    /* ... */
    return ret;
  }
  /* ... */
  if (isPlainObject(nextValue)) {
    const ret = {};
    Object.keys(nextValue).forEach(key => {
      ret[key] = interpolateValue(alpha, nextValue[key], prevValue[key]);
    });
    return ret;
  }
  return nextValue;
}
```

to this:
```js
"use strict";

function interpolateValue(alpha, nextValue, prevValue) {
  /* ... */
  if (nextValue.val != null) {
    var ret = {
      val: interpolateValue(alpha, nextValue.val, prevValue.val)
    };
    /* ... */
    return ret;
  }
  /* ... */
  if (isPlainObject(nextValue)) {
    var _ret = (function () {
      var ret = {};
      Object.keys(nextValue).forEach(function (key) {
        ret[key] = interpolateValue(alpha, nextValue[key], prevValue[key]);
      });
      return {
        v: ret
      };
    })();

    if (typeof _ret === "object") return _ret.v;
  }
  return nextValue;
}
```
[REPL](http://babeljs.io/repl/#?experimental=false&evaluate=true&loose=true&spec=false&playground=false&code=function%20interpolateValue(alpha%2C%20nextValue%2C%20prevValue)%20%7B%0A%20%20%2F*%20...%20*%2F%0A%20%20if%20(nextValue.val%20!%3D%20null)%20%7B%0A%20%20%20%20let%20ret%20%3D%20%7B%0A%20%20%20%20%20%20val%3A%20interpolateValue(alpha%2C%20nextValue.val%2C%20prevValue.val)%2C%0A%20%20%20%20%7D%3B%0A%20%20%20%20%2F*%20...%20*%2F%0A%20%20%20%20return%20ret%3B%0A%20%20%7D%0A%20%20%2F*%20...%20*%2F%0A%20%20if%20(isPlainObject(nextValue))%20%7B%0A%20%20%20%20const%20ret%20%3D%20%7B%7D%3B%0A%20%20%20%20Object.keys(nextValue).forEach(key%20%3D%3E%20%7B%0A%20%20%20%20%20%20ret%5Bkey%5D%20%3D%20interpolateValue(alpha%2C%20nextValue%5Bkey%5D%2C%20prevValue%5Bkey%5D)%3B%0A%20%20%20%20%7D)%3B%0A%20%20%20%20return%20ret%3B%0A%20%20%7D%0A%20%20return%20nextValue%3B%0A%7D%0A)

whereas, if we use `reduce`, Babel doesn't undergo that transform (no after version since it's almost the same):

```js
function interpolateValue(alpha, nextValue, prevValue) {
  /* ... */
  if (nextValue.val != null) {
    let ret = {
      val: interpolateValue(alpha, nextValue.val, prevValue.val),
    };
    /* ... */
    return ret;
  }
  /* ... */
  if (isPlainObject(nextValue)) {
    return Object.keys(nextValue).reduce((ret, key) => {
      ret[key] = interpolateValue(alpha, nextValue[key], prevValue[key]);
      return ret;
    });
  }
  return nextValue;
}
```

[REPL](http://babeljs.io/repl/#?experimental=false&evaluate=true&loose=true&spec=false&playground=false&code=function%20interpolateValue(alpha%2C%20nextValue%2C%20prevValue)%20%7B%0A%20%20%2F*%20...%20*%2F%0A%20%20if%20(nextValue.val%20!%3D%20null)%20%7B%0A%20%20%20%20let%20ret%20%3D%20%7B%0A%20%20%20%20%20%20val%3A%20interpolateValue(alpha%2C%20nextValue.val%2C%20prevValue.val)%2C%0A%20%20%20%20%7D%3B%0A%20%20%20%20%2F*%20...%20*%2F%0A%20%20%20%20return%20ret%3B%0A%20%20%7D%0A%20%20%2F*%20...%20*%2F%0A%20%20if%20(isPlainObject(nextValue))%20%7B%0A%20%20%20%20return%20Object.keys(nextValue).reduce((ret%2C%20key)%20%3D%3E%20%7B%0A%20%20%20%20%20%20ret%5Bkey%5D%20%3D%20interpolateValue(alpha%2C%20nextValue%5Bkey%5D%2C%20prevValue%5Bkey%5D)%3B%0A%20%20%20%20%20%20return%20ret%3B%0A%20%20%20%20%7D)%3B%0A%20%20%7D%0A%20%20return%20nextValue%3B%0A%7D%0A)