### PR TITLE
corrects imports of lodash.isplainobject module

### DIFF
--- a/src/Spring.js
+++ b/src/Spring.js
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 import mapTree from './mapTree';
-import isPlainObject from 'lodash.isPlainObject';
+import isPlainObject from 'lodash.isplainobject';
 import stepper from './stepper';
 import noVelocity from './noVelocity';
 import mergeDiff from './mergeDiff';

--- a/src/mapTree.js
+++ b/src/mapTree.js
@@ -1,4 +1,4 @@
-import isPlainObject from 'lodash.isPlainObject';
+import isPlainObject from 'lodash.isplainobject';
 
 // currenly a helper used for producing a tree of the same shape as the
 // input(s),  but with different values. It's technically not a real `map`

--- a/src/noVelocity.js
+++ b/src/noVelocity.js
@@ -1,4 +1,4 @@
-import isPlainObject from 'lodash.isPlainObject';
+import isPlainObject from 'lodash.isplainobject';
 
 export default function noVelocity(coll) {
   if (Array.isArray(coll)) {


### PR DESCRIPTION
Hi there!

When using react-motion in case-sensitive environments (Linux/Ubuntu), we run into an issue where node, webpack and possibly others can't properly require in the `lodash.isplainobject` module due to current spelling. Note, we've worked around this issue for now by simply aliasing inside of webpack but ideally I think we should use the true name of the module.
