### PR TITLE
Make `willLeave` stop when `currVelocity` is 0 and `currValue` reached dest

### DIFF
--- a/demos/demo3/Demo.jsx
+++ b/demos/demo3/Demo.jsx
@@ -106,13 +106,11 @@ const Demo = React.createClass({
 
   // TODO: change naming
   willLeave(date, valueThatJustLeft) {
-    if (valueThatJustLeft.opacity.val > 0) {
-      return {
-        height: {val: 0},
-        opacity: {val: 0},
-        data: valueThatJustLeft.data,
-      };
-    }
+    return {
+      height: {val: 0},
+      opacity: {val: 0},
+      data: valueThatJustLeft.data,
+    };
   },
 
   render() {

--- a/src/compareTrees.js
+++ b/src/compareTrees.js
@@ -1,0 +1,15 @@
+import isPlainObject from 'lodash.isplainobject';
+
+export default function compareTrees(a, b) {
+  if (Array.isArray(a)) {
+    return a.every((v, i) => compareTrees(v, b[i]));
+  }
+
+  if (isPlainObject(a)) {
+    return Object.keys(a).every(
+      key => key === 'config' ? true : compareTrees(a[key], b[key])
+    );
+  }
+
+  return a === b;
+}


### PR DESCRIPTION
This makes `willLeave` simpler and have a better default behavior. The way to
tell the `TransitionSpring` before this was to add an if statement at the top of
`willLeave` to check if `currValue` has reached the destination and that the
`currVelocity` is 0 and then returning null if yes. We now do that check
internally and do the unmounting when `currValue` is equal to the return of
`endValue` and `currVelocity` is 0.

This "fixes" #104 by just deprecating the API.