### PR TITLE
Passing scalars to `endValue`

### DIFF
--- a/demos/demo0/Demo.jsx
+++ b/demos/demo0/Demo.jsx
@@ -24,8 +24,8 @@ const Demo = React.createClass({
           Toggle
         </button>
 
-        <Spring endValue={{val: this.state.open ? 400 : 0}}>
-          {({val}) =>
+        <Spring endValue={this.state.open ? 400 : 0}>
+          {val =>
             // children is a callback which should accept the current value of
             // `endValue`
             <div className="demo0">

--- a/src/updateTree.js
+++ b/src/updateTree.js
@@ -40,8 +40,8 @@ export function interpolateValue(alpha, nextValue, prevValue) {
   return nextValue;
 }
 
-// TODO: refactor common logic with updateCurrVelocity
-export function updateCurrValue(frameRate, currValue, currVelocity, endValue, k, b) {
+// TODO: refactor common logic with _updateCurrVelocity
+function _updateCurrValue(frameRate, currValue, currVelocity, endValue, k, b) {
   if (endValue == null) {
     return null;
   }
@@ -58,7 +58,7 @@ export function updateCurrValue(frameRate, currValue, currVelocity, endValue, k,
   if (endValue.val != null) {
     const [_k, _b] = endValue.config || presets.noWobble;
     let ret = {
-      val: updateCurrValue(frameRate, currValue.val, currVelocity.val, endValue.val, _k, _b),
+      val: _updateCurrValue(frameRate, currValue.val, currVelocity.val, endValue.val, _k, _b),
     };
     if (endValue.config) {
       ret.config = endValue.config;
@@ -66,18 +66,28 @@ export function updateCurrValue(frameRate, currValue, currVelocity, endValue, k,
     return ret;
   }
   if (Array.isArray(endValue)) {
-    return endValue.map((_, i) => updateCurrValue(frameRate, currValue[i], currVelocity[i], endValue[i], k, b));
+    return endValue.map((_, i) => _updateCurrValue(frameRate, currValue[i], currVelocity[i], endValue[i], k, b));
   }
   if (isPlainObject(endValue)) {
     return Object.keys(endValue).reduce((ret, key) => {
-      ret[key] = updateCurrValue(frameRate, currValue[key], currVelocity[key], endValue[key], k, b);
+      ret[key] = _updateCurrValue(frameRate, currValue[key], currVelocity[key], endValue[key], k, b);
       return ret;
     }, {});
   }
   return endValue;
 }
 
-export function updateCurrVelocity(frameRate, currValue, currVelocity, endValue, k, b) {
+export function updateCurrValue(frameRate, currValue, currVelocity, endValue) {
+  if (typeof endValue === 'number') {
+    const [k, b] = presets.noWobble;
+
+    return stepper(frameRate, currValue, currVelocity, endValue, k, b)[0];
+  }
+
+  return _updateCurrValue(frameRate, currValue, currVelocity, endValue);
+}
+
+function _updateCurrVelocity(frameRate, currValue, currVelocity, endValue, k, b) {
   if (endValue == null) {
     return null;
   }
@@ -94,7 +104,7 @@ export function updateCurrVelocity(frameRate, currValue, currVelocity, endValue,
   if (endValue.val != null) {
     const [_k, _b] = endValue.config || presets.noWobble;
     let ret = {
-      val: updateCurrVelocity(frameRate, currValue.val, currVelocity.val, endValue.val, _k, _b),
+      val: _updateCurrVelocity(frameRate, currValue.val, currVelocity.val, endValue.val, _k, _b),
     };
     if (endValue.config) {
       ret.config = endValue.config;
@@ -102,13 +112,23 @@ export function updateCurrVelocity(frameRate, currValue, currVelocity, endValue,
     return ret;
   }
   if (Array.isArray(endValue)) {
-    return endValue.map((_, i) => updateCurrVelocity(frameRate, currValue[i], currVelocity[i], endValue[i], k, b));
+    return endValue.map((_, i) => _updateCurrVelocity(frameRate, currValue[i], currVelocity[i], endValue[i], k, b));
   }
   if (isPlainObject(endValue)) {
     return Object.keys(endValue).reduce((ret, key) => {
-      ret[key] = updateCurrVelocity(frameRate, currValue[key], currVelocity[key], endValue[key], k, b);
+      ret[key] = _updateCurrVelocity(frameRate, currValue[key], currVelocity[key], endValue[key], k, b);
       return ret;
     }, {});
   }
   return mapTree(zero, currVelocity);
+}
+
+export function updateCurrVelocity(frameRate, currValue, currVelocity, endValue) {
+  if (typeof endValue === 'number') {
+    const [k, b] = presets.noWobble;
+
+    return stepper(frameRate, currValue, currVelocity, endValue, k, b)[1];
+  }
+
+  return _updateCurrVelocity(frameRate, currValue, currVelocity, endValue);
 }

--- a/test/Spring-test.js
+++ b/test/Spring-test.js
@@ -103,7 +103,7 @@ describe('Spring', () => {
     TestUtils.renderIntoDocument(<App />);
   });
 
-  xit('should allow interpolating scalar numbers', done => {
+  it('should allow interpolating scalar numbers', done => {
     let count = [];
     const App = React.createClass({
       render() {
@@ -111,9 +111,12 @@ describe('Spring', () => {
           <Spring defaultValue={0} endValue={10}>
             {val => {
               count.push(val);
+              // count.length being at least 3 we have at least one
+              // intermediary value
               if (count.length > 2 && count[count.length - 1] === 10) {
-                // TODO: make this test work
-                expect(count).toEqual([0, 1232]);
+                expect(count[0]).toBe(0);
+                expect(count[1]).toBeGreaterThan(0);
+                expect(count[count.length - 2]).toBeLessThan(10);
                 done();
               }
               return <div />;


### PR DESCRIPTION
This will allow something like:
```js
<Spring defaultValue={0} endValue={100}>
{val => <div >{val}</div>}
</Spring>
```

We're overloading `endValue` and stepping away from the consistency we had before with `val` and `config`. But this use case seems common enough, and explicit enough, that react-motion could handle it. There is very little confusion as to whether the `Spring` will or not interpolate the _only_ thing it's given.