### PR TITLE
Add mockRaf (combining mocks for `raf` and `performance-now`)

### DIFF
--- a/test/Spring-test.js
+++ b/test/Spring-test.js
@@ -1,27 +1,28 @@
-import React, {addons} from 'react/addons';
+import React, {addons, PropTypes} from 'react/addons';
+
+import createMockRaf from './createMockRaf';
+
 const TestUtils = addons.TestUtils;
 
-const injector = require('inject!../src/Spring');
-// const injectorAnimationLoop = require('inject!../src/animationLoop');
+const injector = require('inject!../src/components');
+const injectorAnimationLoop = require('inject!../src/animationLoop');
 
 describe('Spring', () => {
   let Spring;
   let TransitionSpring;
+  let mockRaf;
+
   beforeEach(() => {
-    Spring = injector({
-      // './animationLoop': injectorAnimationLoop({
-      //   raf: cb => {
-      //     cb();
-      //   },
-      // }),
-    }).Spring;
-    TransitionSpring = injector({
-      // './animationLoop': injectorAnimationLoop({
-      //   raf: cb => {
-      //     cb();
-      //   },
-      // }),
-    }).TransitionSpring;
+    mockRaf = createMockRaf();
+    const bothSprings = injector({
+      './animationLoop': injectorAnimationLoop({
+        raf: mockRaf.raf,
+        'performance-now': mockRaf.now,
+      }),
+    })(React);
+
+    Spring = bothSprings.Spring;
+    TransitionSpring = bothSprings.TransitionSpring;
   });
 
   it('should allow returning null from children function', () => {
@@ -32,9 +33,12 @@ describe('Spring', () => {
       },
     });
     TestUtils.renderIntoDocument(<App />);
+  });
 
+  it('should allow returning null from children function TransitionSpring', () => {
     const App2 = React.createClass({
       render() {
+        // shouldn't throw here
         return (
           <TransitionSpring endValue={{a: {}}}>
             {() => null}
@@ -58,19 +62,14 @@ describe('Spring', () => {
     TestUtils.renderIntoDocument(<App />);
   });
 
-  it('should allow a defaultValue', done => {
+  it('should allow a defaultValue', () => {
     let count = [];
     const App = React.createClass({
       render() {
         return (
-          <Spring defaultValue={{val: 1}} endValue={{val: 10}}>
+          <Spring defaultValue={{val: 0}} endValue={{val: 10}}>
             {({val}) => {
               count.push(val);
-              if (count.length === 2) {
-                expect(count[0]).toBe(1);
-                expect(count[1]).toBeGreaterThan(1);
-                setTimeout(done, 0);
-              }
               return null;
             }}
           </Spring>
@@ -78,21 +77,29 @@ describe('Spring', () => {
       },
     });
     TestUtils.renderIntoDocument(<App />);
+
+    // Initial render
+    expect(count).toEqual([0]);
+
+    // Move "time" by 8 steps, which is equivalent to 8 calls to `raf`
+    mockRaf.manySteps(4);
+    expect(count).toEqual([
+      0,
+      0.4722222222222222,
+      1.161037037037037,
+      1.9465593192729767,
+      2.7545195845240817]);
   });
 
-  it('should allow a defaultValue for TransitionSpring', done => {
+  it('should allow a defaultValue for TransitionSpring', () => {
     let count = [];
     const App = React.createClass({
       render() {
         return (
-          <TransitionSpring defaultValue={{a: {val: 1}}} endValue={{a: {val: 10}}}>
-            {({a: {val}}) => {
+          <TransitionSpring defaultValue={{val: 0}} endValue={{val: 10}}>
+            {({val}) => {
               count.push(val);
-              if (count.length === 2) {
-                expect(count[0]).toBe(1);
-                expect(count[1]).toBeGreaterThan(1);
-                setTimeout(done, 0);
-              }
+
               return null;
             }}
           </TransitionSpring>
@@ -101,9 +108,77 @@ describe('Spring', () => {
     });
 
     TestUtils.renderIntoDocument(<App />);
+
+    // Initial render
+    expect(count).toEqual([0]);
+    mockRaf.manySteps(4);
+    expect(count).toEqual([
+      0,
+      0.4722222222222222,
+      1.161037037037037,
+      1.9465593192729767,
+      2.7545195845240817]);
   });
 
-  it('should allow interpolating scalar numbers', done => {
+  it('should interpolate nested objects', () => {
+    let count = [];
+    const App = React.createClass({
+      render() {
+        return (
+          <Spring defaultValue={{a: {val: 0}, b: {c: {val: 0}}}} endValue={{a: {val: 10}, b: {c: {val: 400}}}}>
+            {({a: {val}, b: {c: {val: val2}}}) => {
+              count.push([val, val2]);
+
+              return null;
+            }}
+          </Spring>
+        );
+      },
+    });
+
+    TestUtils.renderIntoDocument(<App />);
+
+    // Initial render
+    expect(count).toEqual([[0, 0]]);
+    mockRaf.manySteps(4);
+    expect(count).toEqual([
+      [0, 0],
+      [0.4722222222222222, 18.888888888888886],
+      [1.161037037037037, 46.441481481481475],
+      [1.9465593192729767, 77.86237277091905],
+      [2.7545195845240817, 110.18078338096325]]);
+  });
+
+  it('should interpolate nested objects TransitionSpring', () => {
+    let count = [];
+    const App = React.createClass({
+      render() {
+        return (
+          <TransitionSpring defaultValue={{a: {val: 0}, b: {c: {val: 0}}}} endValue={{a: {val: 10}, b: {c: {val: 400}}}}>
+            {({a: {val}, b: {c: {val: val2}}}) => {
+              count.push([val, val2]);
+
+              return null;
+            }}
+          </TransitionSpring>
+        );
+      },
+    });
+
+    TestUtils.renderIntoDocument(<App />);
+
+    // Initial render
+    expect(count).toEqual([[0, 0]]);
+    mockRaf.manySteps(4);
+    expect(count).toEqual([
+      [0, 0],
+      [0.4722222222222222, 18.888888888888886],
+      [1.161037037037037, 46.441481481481475],
+      [1.9465593192729767, 77.86237277091905],
+      [2.7545195845240817, 110.18078338096325]]);
+  });
+
+  it('should allow interpolating scalar numbers', () => {
     let count = [];
     const App = React.createClass({
       render() {
@@ -111,14 +186,6 @@ describe('Spring', () => {
           <Spring defaultValue={0} endValue={10}>
             {val => {
               count.push(val);
-              // count.length being at least 3 we have at least one
-              // intermediary value
-              if (count.length > 2 && count[count.length - 1] === 10) {
-                expect(count[0]).toBe(0);
-                expect(count[1]).toBeGreaterThan(0);
-                expect(count[count.length - 2]).toBeLessThan(10);
-                setTimeout(done, 0);
-              }
               return <div />;
             }}
           </Spring>
@@ -126,9 +193,19 @@ describe('Spring', () => {
       },
     });
     TestUtils.renderIntoDocument(<App />);
+
+    // Initial render
+    expect(count).toEqual([0]);
+    mockRaf.manySteps(4);
+    expect(count).toEqual([
+      0,
+      0.4722222222222222,
+      1.161037037037037,
+      1.9465593192729767,
+      2.7545195845240817]);
   });
 
-  it('should call raf one more time after it is done animating', done => {
+  it('should call raf one more time after it is done animating', () => {
     let count = [];
     const App = React.createClass({
       render() {
@@ -136,10 +213,6 @@ describe('Spring', () => {
           <Spring endValue={{val: 400}}>
             {({val}) => {
               count.push(val);
-              if (count.length === 2) {
-                expect(count).toEqual([400, 400]);
-                done();
-              }
               return <div />;
             }}
           </Spring>
@@ -147,9 +220,14 @@ describe('Spring', () => {
       },
     });
     TestUtils.renderIntoDocument(<App />);
+
+    // Initial render
+    expect(count).toEqual([400]);
+    mockRaf.manySteps(10); // Shouldn't matter, we stop rafing
+    expect(count).toEqual([400, 400]);
   });
 
-  xit('should pass the new value', done => {
+  it('should pass the new value', () => {
     let count = [];
     const App = React.createClass({
       render() {
@@ -157,9 +235,6 @@ describe('Spring', () => {
           <Spring defaultValue={{val: 0}} endValue={{val: 400}}>
             {({val}) => {
               count.push(val);
-              if (count.length > 2 && count[count.length - 1] === 400) {
-                done();
-              }
               return <div />;
             }}
           </Spring>
@@ -167,26 +242,60 @@ describe('Spring', () => {
       },
     });
     TestUtils.renderIntoDocument(<App />);
+
+    // Initial render
+    expect(count).toEqual([0]);
+    mockRaf.manySteps(4);
+    expect(count).toEqual([
+      0,
+      18.888888888888886,
+      46.441481481481475,
+      77.86237277091905,
+      110.18078338096325]);
   });
 
-  xit('should work with nested springs', done => {
+  it('should work with nested springs', () => {
     let count = [];
     const App = React.createClass({
       render() {
         return (
-          <Spring endValue={{val: 400}}>
-            {({val}) => {
-              count.push(val);
-              return <div />;
-            }}
+          <Spring endValue={{ownerVal: 10}}>
+          {({ownerVal}) => {
+            count.push(ownerVal);
+            return (
+              <Spring endValue={{val: 400}}>
+                {({val}) => {
+                  count.push(val);
+                  return <div />;
+                }}
+              </Spring>
+            );
+          }}
           </Spring>
         );
       },
     });
     TestUtils.renderIntoDocument(<App />);
-    setTimeout(() => {
-      expect(count).toEqual([400, 400]);
-      done();
-    }, 0);
+
+    // Here's why we expect this with the current
+    // implementation (not necessarily good):
+    //
+    // - mount <App />
+    // - render owner Spring           [10]
+    // - the above triggers the child  [10, 400]
+    //   Spring to render
+    // - step once (both Spring
+    //   calculations are done in the
+    //   same step)
+    // - render the child Spring       [10, 400, 400]
+    // - render the owner Spring       [10, 400, 400, 10]
+    // - the above triggers the child  [10, 400, 400, 10, 400]
+    //   Spring to render
+
+    expect(count).toEqual([10, 400]);
+    mockRaf.step();
+    expect(count).toEqual([10, 400, 400, 10, 400]);
+    mockRaf.step();
+    expect(count).toEqual([10, 400, 400, 10, 400]);
   });
 });

--- a/test/createMockRaf.js
+++ b/test/createMockRaf.js
@@ -1,0 +1,29 @@
+export default function() {
+  let allCallbacks = [];
+  let prevTime = 0;
+
+  const now = () => {
+    return prevTime;
+  };
+
+  const raf = cb => {
+    allCallbacks.push(cb);
+  };
+
+  const step = (ms = 16) => {
+    const allCallbacksBefore = allCallbacks;
+    allCallbacks = [];
+
+    allCallbacksBefore.forEach(cb => cb());
+
+    prevTime += ms;
+  };
+
+  const manySteps = (num = 1) => {
+    for (let i = 0; i < num; i++) {
+      step();
+    }
+  };
+
+  return {now, raf, step, manySteps};
+};


### PR DESCRIPTION
The title says it all.

I also adapted the tests to use that mock `raf`. The main advantages of using a mock `raf` is that the tests become synchronous, making them much easier to reason about. They also make the whole system deterministic. This means that when we call `mockRaf.step()` 10 times with the same Spring (and same constants),  `currValue` will always take the same values in the same order.

There are two main functions that can be used:
- `mockRaf.step(ms = 16)` - will step "time" by one frame and by `ms` amount of milliseconds. This will call all `raf`s that were registered in the last frame.
- `mockRaf.manySteps(numberOfSteps = 1)` - will call `mockRaf.step` `numberOfSteps` times

The two other functions are the mock functions. They can be used like follow:
```js
const injector = require('inject!../src/components');
const injectorAnimationLoop = require('inject!../src/animationLoop');
const {Spring, TransitionSpring} = injector({
  './animationLoop': injectorAnimationLoop({
    raf: mockRaf.getRaf(), // Will return a raf function that will just queue the callback
    'performance-now': mockRaf.getNow(), // Will return a now() function
  }),
})(React);
```