### PR TITLE
Remove mutation inside `TransitionSpring` when new key enters

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -45,12 +45,20 @@ function animationStep(shouldMerge, stopAnimation, getProps, timestep, state) {
       .forEach(key => {
         hasNewKey = true;
         const enterValue = willEnter(key, mergedValue[key], endValue, currValue, currVelocity);
-        currValue[key] = enterValue;
+
+        // We can mutate this here because mergeDiff returns a new Obj
         mergedValue[key] = enterValue;
-        currVelocity[key] = mapTree(zero, currValue[key]);
+
+        currValue = {
+          ...currValue,
+          [key]: enterValue,
+        };
+        currVelocity = {
+          ...currVelocity,
+          [key]: mapTree(zero, enterValue),
+        };
       });
   }
-
   const newCurrValue = updateCurrValue(timestep, currValue, currVelocity, mergedValue);
   const newCurrVelocity = updateCurrVelocity(timestep, currValue, currVelocity, mergedValue);
 

--- a/test/Spring-test.js
+++ b/test/Spring-test.js
@@ -335,4 +335,60 @@ describe('Spring', () => {
       // towards that. So when the loop was broken, 177.2738043339909 would be
       // 146.83959701218743
   });
+
+  it('should not mutate currValue when adding a new key (TransitionSpring)', () => {
+    let count = [];
+
+    const App = React.createClass({
+      getInitialState() {
+        return {
+          data: {
+            key1: { val: 10 },
+            key2: { val: 10 },
+          },
+        };
+      },
+
+      componentDidMount() {
+        this.setState({
+          data: {
+            key1: { val: 10 },
+            key2: { val: 10 },
+            key3: { val: 10 },
+          },
+        });
+      },
+
+      render() {
+        return (
+          <TransitionSpring
+            endValue={this.state.data}
+            willEnter={() => ({ val: 0 })}
+            willLeave={() => ({ val: 0 })}>
+            {currValue => {
+              count.push(currValue);
+              return null;
+            }}
+          </TransitionSpring>
+        );
+      },
+    });
+    TestUtils.renderIntoDocument(<App />);
+
+    mockRaf.step();
+
+    expect(count).toEqual([
+      {
+        key1: { val: 10 },
+        key2: { val: 10 },
+      }, { // This second obj would be mutated
+        key1: { val: 10 },
+        key2: { val: 10 },
+      }, {
+        key1: { val: 10 },
+        key2: { val: 10 },
+        key3: { val: 0 },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
We [mutate](https://github.com/chenglou/react-motion/blob/84985fd8bc0f10d4477bbfbf5bf779dfa3be85f9/src/components.js#L48-L50) `currValue[key]` when a new element enters the scene. This could be
reflected in user land. If you push `currValue` in an array inside the
child-as-function in the `TransitionSpring`, then you'd see that element get
mutated when a new element entered the scene.