### PR TITLE
Fix animationLoop when iterating over more than 1 frame.

### DIFF
--- a/src/animationLoop.js
+++ b/src/animationLoop.js
@@ -28,7 +28,9 @@ export default function configAnimation(config = {}) {
 
     let frameNumber = Math.ceil(accumulatedTime / timeStep);
     for (let i = 0; i < animRunning.length; i++) {
-      const {active, step, prevState: prevPrevState, nextState: prevNextState} = animRunning[i];
+      const {active, step, prevState: prevPrevState} = animRunning[i];
+      let {nextState: prevNextState} = animRunning[i];
+
       if (!active) {
         continue;
       }
@@ -49,6 +51,7 @@ export default function configAnimation(config = {}) {
         for (let j = 0; j < frameNumber; j++) {
           animRunning[i].nextState = step(timeStep / 1000, prevNextState);
           animRunning[i].prevState = prevNextState;
+          prevNextState = animRunning[i].nextState;
         }
       }
     }

--- a/src/animationLoop.js
+++ b/src/animationLoop.js
@@ -50,8 +50,7 @@ export default function configAnimation(config = {}) {
       } else {
         for (let j = 0; j < frameNumber; j++) {
           animRunning[i].nextState = step(timeStep / 1000, prevNextState);
-          animRunning[i].prevState = prevNextState;
-          prevNextState = animRunning[i].nextState;
+          [animRunning[i].prevState, prevNextState] = [prevNextState, animRunning[i].nextState];
         }
       }
     }

--- a/test/Spring-test.js
+++ b/test/Spring-test.js
@@ -298,4 +298,41 @@ describe('Spring', () => {
     mockRaf.step();
     expect(count).toEqual([10, 400, 400, 10, 400]);
   });
+
+  it('should be able to move by two steps if Spring gets out of sync', () => {
+    let count = [];
+    const App = React.createClass({
+      render() {
+        return (
+          <Spring defaultValue={{val: 0}} endValue={{val: 400}}>
+            {({val}) => {
+              count.push(val);
+              return <div />;
+            }}
+          </Spring>
+        );
+      },
+    });
+    TestUtils.renderIntoDocument(<App />);
+
+    // Initial render
+    expect(count).toEqual([0]);
+    mockRaf.manySteps(6);
+    expect(count).toEqual([
+      0,
+      18.888888888888886,
+      47.589506172839506,
+      80.49479595336076,
+      114.22887257563632,
+      146.83959701218743,
+      177.2738043339909]);
+      // Due to floating point errors when calculating the accumulated time
+      // inside the animationLoop, arriving at that last value the accumulated
+      // time will go barely beyond 1000/60 and so the animation loop will move
+      // by two frames but will only move by say 1% towards that 2nd frame.
+      // Before the for loop calculating more than one frame would just
+      // calculate the same frame over and over again, but we'd still move 1%
+      // towards that. So when the loop was broken, 177.2738043339909 would be
+      // 146.83959701218743
+  });
 });


### PR DESCRIPTION
Seems like this bug was introduced [here](https://github.com/chenglou/react-motion/commit/ff5399b2cb9ba8127d6b6b4cce5d8a5c8a3f90eb).
We calculate the `frameNumber` next frames, but never update
`prevNextState` which is the state passed to `step`. So we just
calculate the same frame over and over again.

Added test to prevent this next time.