### PR TITLE
Fix a bug in animationLoop when having nested Springs.

### DIFF
--- a/src/animationLoop.js
+++ b/src/animationLoop.js
@@ -58,14 +58,17 @@ export default function configAnimation(config = {}) {
     accumulatedTime = accumulatedTime - frameNumber * timeStep;
 
     // Render and filter in one iteration.
-    const newAnimRunning = [];
     const alpha = 1 + accumulatedTime / timeStep;
     for (let i = 0; i < animRunning.length; i++) {
-      const {render, active, nextState, prevState} = animRunning[i];
+      const {render, nextState, prevState} = animRunning[i];
 
       // Might mutate animRunning........
       render(alpha, nextState, prevState);
-      if (active) {
+    }
+
+    let newAnimRunning = [];
+    for (let i = 0; i < animRunning.length; i++) {
+      if (animRunning[i].active) {
         newAnimRunning.push(animRunning[i]);
       }
     }

--- a/test/Spring-test.js
+++ b/test/Spring-test.js
@@ -277,26 +277,27 @@ describe('Spring', () => {
     });
     TestUtils.renderIntoDocument(<App />);
 
-    // Here's why we expect this with the current
-    // implementation (not necessarily good):
+    // Here's why we expect this with the current implementation:
     //
     // - mount <App />
-    // - render owner Spring           [10]
-    // - the above triggers the child  [10, 400]
-    //   Spring to render
-    // - step once (both Spring
-    //   calculations are done in the
-    //   same step)
-    // - render the child Spring       [10, 400, 400]
-    // - render the owner Spring       [10, 400, 400, 10]
-    // - the above triggers the child  [10, 400, 400, 10, 400]
-    //   Spring to render
+    // - render owner Spring                           [10]
+    // - the above triggers the child Spring to render [10, 400]
+    // - step once (both Spring calculations are done
+    //   in the same step)
+    // - render the child Spring                       [10, 400, 400]
+    // - render the owner Spring                       [10, 400, 400, 10]
+    // - the above triggers the child Spring to render [10, 400, 400, 10, 400]
+    // - step a second time which only affects the
+    //   child who registered one last raf in the step
+    //   above
 
     expect(count).toEqual([10, 400]);
     mockRaf.step();
     expect(count).toEqual([10, 400, 400, 10, 400]);
-    mockRaf.step();
-    expect(count).toEqual([10, 400, 400, 10, 400]);
+
+    // Step many times won't matter, the child only renders once more
+    mockRaf.manySteps(10);
+    expect(count).toEqual([10, 400, 400, 10, 400, 400]);
   });
 
   it('should be able to move by two steps if Spring gets out of sync', () => {


### PR DESCRIPTION
This one was hard to track down. Say you have two springs one inside
the other, there's the `owner` and the `child`. They both mount, and
therefore call `startAnimation` which will register a `raf`.

The `child` steps first because it registered the `raf` callback first.
In the step it checks `noVelocity` and say in our case it's true, it'll
calls `stopAnimation`. `stopAnimation` will set `val.active = false`.
Then the `owner` steps.

We then loop through the `Spring`s, starting with the `child` and
render them. We render the `child` and check if `child.active` is true.
In our case it's not, so we don't push it in the array of future `raf`s.

We then render the `owner` which makes the `child` render and call
`startAnimation`. The call to `startAnimation` will set
`val.active = true`, but it's too late, we decided not to push that
Spring in the array of future `raf`s at the last tick of the loop.
That render is done we check the length of that array and see that it's
empty, so we stop.

The fix is to call all of the renders first, and then loop through
the `Spring`s and push in the future `raf`s array what needs to step.

This includes a test.