### PR TITLE
Update inject-loader to use 2.0.1 now it’s published

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint-config-airbnb": "0.0.6",
     "eslint-loader": "^0.14.1",
     "eslint-plugin-react": "^2.7.0",
-    "inject-loader": "plasticine/inject-loader#master",
+    "inject-loader": "^2.0.1",
     "isparta-loader": "^0.2.0",
     "karma": "^0.12.37",
     "karma-coverage": "^0.4.2",


### PR DESCRIPTION
Hey there :)

I’m the author of inject-loader. This PR gets react-motion off the master branch of inject-loader and onto a published version (2.0.1 to be precise), which now includes the code that necessitated using master in the past