### PR TITLE
ignore react for browserify build

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "type": "git",
     "url": "https://github.com/chenglou/react-motion.git"
   },
+  "browser":{
+    "react": false
+  },
   "keywords": [
     "react",
     "component",


### PR DESCRIPTION
A know issue with [browserify-cdn](https://www.google.co.in/search?q=browserify+cdn+peerdependencies&oq=browserify+cdn+pee&aqs=chrome.0.69i59j69i57j69i60.5598j1j7&sourceid=chrome&es_sm=91&ie=UTF-8), is that it fails on peerDependencies. As such, it tries to bundle react, doesn't find it installed, and [bails with an error](https://wzrd.in/standalone/react-motion). This should fix that.