### PR TITLE
set this.hasUnmounted to false in componentWillUnmount method of the TransitionSpring component

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -352,6 +352,7 @@ for the upgrade path. Thank you!`
 
     componentWillUnmount() {
       this.stopAnimation();
+      this.hasUnmounted = true;
     },
 
     startAnimating() {


### PR DESCRIPTION
I was working on a component that uses react-motion and noticed that it caused react to throw the setState warning when I went to a new route. I located the source of this issue in `src/components.js` in TransitionSpring's `animationRender` method. The Spring component sets `this.hasUnmounted` to `false` in `componentWillUnmount` but TransitionSpring does not. When `animationRender` checks `!this.hasUnmounted` it evaluates to true and the setState code is run causing react to throw the warning. So I added `this.hasUnmounted = true;` to `componentWillUnmount` in TransitionSpring. The warning is no longer thrown.