### PR TITLE
Update React peerDependency to rc1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A spring that solves your animation problems.",
   "main": "lib/react-motion.js",
   "peerDependencies": {
-    "react": ">=0.13.2 || ^0.14.0-beta1"
+    "react": ">=0.13.2 || ^0.14.0-rc1"
   },
   "devDependencies": {
     "babel": "^5.6.14",


### PR DESCRIPTION
To enable smooth usage of React 0.14 RC1 without NPM errors on install.