### PR TITLE
Add missing jasmine dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint-plugin-react": "^2.7.0",
     "inject-loader": "^2.0.1",
     "isparta-loader": "^0.2.0",
+    "jasmine-core": "^2.3.4",
     "karma": "^0.12.37",
     "karma-coverage": "^0.4.2",
     "karma-jasmine": "^0.3.6",


### PR DESCRIPTION
Hi, when I tried to run `npm test`, it failed at first because the `jasmine-core` dependency was missing. Per karma-jasmine documentation (https://github.com/karma-runner/karma-jasmine) since 0.3.0 you need to add an explicit `jasmine-core` dependency since karma-jasmine does not pull it any more.