### PR TITLE
Handle `undefined` and `null` in style objects

### DIFF
--- a/src/hasReachedStyle.js
+++ b/src/hasReachedStyle.js
@@ -5,7 +5,7 @@ export default function hasReachedStyle(currentStyle, style) {
     }
     const currentValue = currentStyle[key];
     const destValue = style[key];
-    if (!destValue.config) {
+    if (destValue == null || !destValue.config) {
       // not a spring config
       continue;
     }

--- a/src/noVelocity.js
+++ b/src/noVelocity.js
@@ -5,7 +5,7 @@ export default function noVelocity(currentVelocity, currentStyle) {
     if (!currentVelocity.hasOwnProperty(key)) {
       continue;
     }
-    if (currentStyle[key].config && currentVelocity[key] !== 0) {
+    if (currentStyle[key] != null && currentStyle[key].config && currentVelocity[key] !== 0) {
       return false;
     }
   }

--- a/src/stripStyle.js
+++ b/src/stripStyle.js
@@ -5,7 +5,7 @@ export default function stripStyle(style) {
     if (!style.hasOwnProperty(key)) {
       continue;
     }
-    ret[key] = style[key].val == null ? style[key] : style[key].val;
+    ret[key] = style[key] == null || style[key].val == null ? style[key] : style[key].val;
   }
   return ret;
 }

--- a/src/updateTree.js
+++ b/src/updateTree.js
@@ -13,7 +13,7 @@ export function interpolateValue(alpha, nextStyle, prevStyle) {
       continue;
     }
 
-    if (!nextStyle[key].config) {
+    if (nextStyle[key] == null || !nextStyle[key].config) {
       ret[key] = nextStyle[key];
       // not a spring config, not something we want to interpolate
       continue;
@@ -35,7 +35,7 @@ export function updateCurrentStyle(frameRate, currentStyle, currentVelocity, sty
     if (!style.hasOwnProperty(key)) {
       continue;
     }
-    if (!style[key].config) {
+    if (style[key] == null || !style[key].config) {
       ret[key] = style[key];
       // not a spring config, not something we want to interpolate
       continue;
@@ -64,7 +64,7 @@ export function updateCurrentVelocity(frameRate, currentStyle, currentVelocity, 
     if (!style.hasOwnProperty(key)) {
       continue;
     }
-    if (!style[key].config) {
+    if (style[key] == null || !style[key].config) {
       // not a spring config, not something we want to interpolate
       ret[key] = 0;
       continue;

--- a/test/hasReachedStyle-test.js
+++ b/test/hasReachedStyle-test.js
@@ -10,6 +10,10 @@ describe('hasReachedStyle', () => {
     expect(hasReachedStyle({a: 10}, {a: 5})).toBe(true);
   });
 
+  it('should ignore `undefined`', () => {
+    expect(hasReachedStyle({a: undefined}, {a: undefined})).toBe(true);
+  });
+
   it('should return true of the final value is reached', () => {
     const currentStyle = {
       a: spring(2),

--- a/test/noVelocity-test.js
+++ b/test/noVelocity-test.js
@@ -10,6 +10,10 @@ describe('noVelocity', () => {
     expect(noVelocity({a: 10, b: 0}, {a: 1, b: spring(1)})).toBe(true);
   });
 
+  it('should ignore `undefined`', () => {
+    expect(noVelocity({a: undefined}, {a: undefined})).toBe(true);
+  });
+
   it('should return false if there is at least 1 configured val not 0', () => {
     expect(noVelocity({a: 1, b: 0}, {a: spring(1), b: spring(1)})).toBe(false);
     expect(noVelocity({a: 1, b: 1}, {a: 1, b: spring(1)})).toBe(false);

--- a/test/stripStyle-test.js
+++ b/test/stripStyle-test.js
@@ -1,0 +1,7 @@
+import stripStyle from '../src/stripStyle';
+
+describe('stripStyle', () => {
+  it('should ignore `undefined`', () => {
+    expect(stripStyle({a: undefined})).toEqual({a: undefined});
+  });
+});

--- a/test/updateTree-test.js
+++ b/test/updateTree-test.js
@@ -1,7 +1,15 @@
-import {updateCurrentStyle, updateCurrentVelocity} from '../src/updateTree';
+import {interpolateValue, updateCurrentStyle, updateCurrentVelocity} from '../src/updateTree';
 import {spring} from '../src/react-motion';
 
 const FRAME_RATE = 1 / 60;
+
+describe('interpolateValue', () => {
+  it('should handle `undefined`', () => {
+    const nextStyle = {a: undefined};
+    const prevStyle = {a: undefined};
+    expect(interpolateValue(1, nextStyle, prevStyle)).toEqual({a: undefined});
+  });
+});
 
 describe('updateCurrentStyle', () => {
   it('should jump to style when there is no config', () => {
@@ -18,6 +26,14 @@ describe('updateCurrentStyle', () => {
     const style = {a: 100, b: spring(10)};
     expect(updateCurrentStyle(FRAME_RATE, currentStyle, currentVelocity, style))
       .toEqual({a: 100, b: {val: 3.34, config: [170, 26]}});
+  });
+
+  it('should handle `undefined`', () => {
+    const currentStyle = {a: undefined};
+    const currentVelocity = {a: undefined};
+    const style = {a: undefined};
+    expect(updateCurrentStyle(FRAME_RATE, currentStyle, currentVelocity, style))
+      .toEqual({a: undefined});
   });
 
   it('should do negative numbers', () => {
@@ -63,6 +79,14 @@ describe('updateCurrentVelocity', () => {
     const style = {a: 100, b: spring(10)};
     expect(updateCurrentVelocity(FRAME_RATE, currentStyle, currentVelocity, style))
       .toEqual({a: 0, b: 20.4});
+  });
+
+  it('should handle `undefined`', () => {
+    const currentStyle = {a: undefined};
+    const currentVelocity = {a: undefined};
+    const style = {a: undefined};
+    expect(updateCurrentVelocity(FRAME_RATE, currentStyle, currentVelocity, style))
+      .toEqual({a: 0});
   });
 
   it('should do negative numbers', () => {


### PR DESCRIPTION
I am upgrading from 0.2.7 to 0.3.0 and I ran into an error:

> Uncaught TypeError: Cannot read property 'config' of undefined

This happens when I am using a `TransitionMotion` with a style object
that has a key who's value is `undefined`, e.g.:

  {
    opacity: spring(0),
    extraText: undefined,
  }

To make react-motion easier to work with, I have added guards in a
number of places.

Fixes #180.