### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+
+sudo: false
+
+cache:
+  directories:
+    - node_modules
+
+node_js:
+  - 4
+
+script: npm run lint && npm run test:travis

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # React-Motion
 
+[![Build Status](https://travis-ci.org/chenglou/react-motion.svg?branch=master)](https://travis-ci.org/chenglou/react-motion)
 [![npm version](https://badge.fury.io/js/react-motion.svg)](https://www.npmjs.com/package/react-motion)
 [![Bower version](https://badge.fury.io/bo/react-motion.svg)](http://badge.fury.io/bo/react-motion)
 [![react-motion channel on slack](https://img.shields.io/badge/slack-react--motion%40reactiflux-61DAAA.svg?style=flat)](http://reactiflux.herokuapp.com)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prerelease": "babel src --out-dir lib && babel native/non-compiled.js > native/index.js && NODE_ENV=production webpack --config webpack.prod.config.js",
     "karma": "NODE_ENV=development karma start ./karma.conf.js",
     "test": "npm run karma --  --single-run --reporters nyan",
+    "test:travis": "npm run karma --  --single-run",
     "test:dev": "npm run karma -- --no-single-run --auto-watch --reporters nyan",
     "test:cov": "COVERAGE=1 npm run karma -- --single-run --reporters coverage"
   },


### PR DESCRIPTION
This will tell Travis CI how to test this project. This configuration
needs to be coupled with someone who has permissions on the GitHub repo
to enable the Travis CI webhook.

The nyan cat reporter didn't work very well in the Travis output, so I
decided to just use the default reporter for this integration.

[Closes #182]