### PR TITLE
Automate publish to gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:travis": "karma start ./karma.conf.js --single-run",
     "test:dev": "karma start ./karma.conf.js --no-single-run --auto-watch",
     "test:cov": "karma start ./karma.conf.js --single-run --reporters coverage",
-    "gh-pages": "git fetch origin && git checkout gh-pages && git rebase origin/master --force-rebase && npm run build-demos && git add . && git commit --amend --no-edit && git push origin gh-pages --force && git checkout master"
+    "gh-pages": "git fetch origin && git checkout gh-pages && git reset --hard origin/gh-pages && git rebase origin/master --force-rebase && npm run build-demos && git add . && git commit --amend --no-edit && git push origin gh-pages --force && git checkout master"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "test:travis": "karma start ./karma.conf.js --single-run",
     "test:dev": "karma start ./karma.conf.js --no-single-run --auto-watch",
     "test:cov": "karma start ./karma.conf.js --single-run --reporters coverage",
-    "pregh-pages": "git fetch origin",
-    "gh-pages": "git checkout gh-pages && git rebase origin/master --force-rebase && npm run build-demos && git add . && git commit --amend --no-edit && git push origin gh-pages --force && git checkout master"
+    "gh-pages": "git fetch origin && git checkout gh-pages && git rebase origin/master --force-rebase && npm run build-demos && git add . && git commit --amend --no-edit && git push origin gh-pages --force && git checkout master"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "test": "karma start ./karma.conf.js --single-run",
     "test:travis": "karma start ./karma.conf.js --single-run",
     "test:dev": "karma start ./karma.conf.js --no-single-run --auto-watch",
-    "test:cov": "karma start ./karma.conf.js --single-run --reporters coverage"
+    "test:cov": "karma start ./karma.conf.js --single-run --reporters coverage",
+    "pregh-pages": "git fetch origin",
+    "gh-pages": "git checkout gh-pages && git rebase origin/master --force-rebase && npm run build-demos && git add . && git commit --amend --no-edit && git push origin gh-pages --force && git checkout master"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Works ok for me. If in doubts, you can always run commands one-by-one manually...

### Expanded view:

```sh
git fetch origin

git checkout gh-pages

# Cleanup any potential leftovers
git reset --hard origin/gh-pages 

git rebase origin/master --force-rebase

npm run build-demos

git add .

# Overwrite previous commit (which is `Build`) with fresh new stuff
git commit --amend --no-edit

# Force-pushing
git push origin gh-pages --force

# Go back to master
git checkout master

```

### Example run

```sh
C:\www\react-animation (auto-gh-pages)
λ npm run gh-pages

> react-motion@0.3.0 gh-pages C:\www\react-animation
> git fetch origin && git checkout gh-pages && git reset --hard origin/gh-pages && git rebase origin/master --force-rebase && npm run build-demos && git add . && git commit --amend --no-edit && git push origin gh-pages --force && git checkout master

Switched to branch 'gh-pages'
Your branch is up-to-date with 'origin/gh-pages'.
HEAD is now at 5de8fa2 Build
Current branch gh-pages is up to date, rebase forced.
First, rewinding head to replay your work on top of it...
Applying: Allow built demos
Applying: Build

> react-motion@0.3.0 build-demos C:\www\react-animation
> webpack

Hash: 6dc2fdef45da3582faad
Version: webpack 1.12.2
Time: 13142ms
                                     Asset     Size  Chunks             Chunk Names
                          demo6/all.js.map     3 MB       0  [emitted]  demo6
                              demo6/all.js  2.48 MB       0  [emitted]  demo6
    demo5-spring-parameters-chooser/all.js   697 kB       2  [emitted]  demo5-spring-parameters-chooser
              demo2-draggable-balls/all.js   695 kB       3  [emitted]  demo2-draggable-balls
                   demo1-chat-heads/all.js   692 kB       4  [emitted]  demo1-chat-heads
                demo7-water-ripples/all.js   686 kB       5  [emitted]  demo7-water-ripples
                demo4-photo-gallery/all.js   687 kB       6  [emitted]  demo4-photo-gallery
      demo3-todomvc-list-transition/all.js   692 kB       7  [emitted]  demo3-todomvc-list-transition
            demo0-simple-transition/all.js   684 kB       8  [emitted]  demo0-simple-transition
               demo8-draggable-list/all.js   693 kB       1  [emitted]  demo8-draggable-list
           demo8-draggable-list/all.js.map   843 kB       1  [emitted]  demo8-draggable-list
demo5-spring-parameters-chooser/all.js.map   847 kB       2  [emitted]  demo5-spring-parameters-chooser
          demo2-draggable-balls/all.js.map   846 kB       3  [emitted]  demo2-draggable-balls
               demo1-chat-heads/all.js.map   840 kB       4  [emitted]  demo1-chat-heads
            demo7-water-ripples/all.js.map   832 kB       5  [emitted]  demo7-water-ripples
            demo4-photo-gallery/all.js.map   835 kB       6  [emitted]  demo4-photo-gallery
  demo3-todomvc-list-transition/all.js.map   842 kB       7  [emitted]  demo3-todomvc-list-transition
        demo0-simple-transition/all.js.map   831 kB       8  [emitted]  demo0-simple-transition
    + 203 hidden modules
warning: CRLF will be replaced by LF in demos/demo6/all.js.
The file will have its original line endings in your working directory.
[gh-pages be54b92] Build
warning: CRLF will be replaced by LF in demos/demo6/all.js.
The file will have its original line endings in your working directory.
 18 files changed, 195697 insertions(+)
 create mode 100644 demos/demo0-simple-transition/all.js
 create mode 100644 demos/demo0-simple-transition/all.js.map
 create mode 100644 demos/demo1-chat-heads/all.js
 create mode 100644 demos/demo1-chat-heads/all.js.map
 create mode 100644 demos/demo2-draggable-balls/all.js
 create mode 100644 demos/demo2-draggable-balls/all.js.map
 create mode 100644 demos/demo3-todomvc-list-transition/all.js
 create mode 100644 demos/demo3-todomvc-list-transition/all.js.map
 create mode 100644 demos/demo4-photo-gallery/all.js
 create mode 100644 demos/demo4-photo-gallery/all.js.map
 create mode 100644 demos/demo5-spring-parameters-chooser/all.js
 create mode 100644 demos/demo5-spring-parameters-chooser/all.js.map
 create mode 100644 demos/demo6/all.js
 create mode 100644 demos/demo6/all.js.map
 create mode 100644 demos/demo7-water-ripples/all.js
 create mode 100644 demos/demo7-water-ripples/all.js.map
 create mode 100644 demos/demo8-draggable-list/all.js
 create mode 100644 demos/demo8-draggable-list/all.js.map
Counting objects: 13, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 407 bytes | 0 bytes/s, done.
Total 3 (delta 1), reused 0 (delta 0)
To git@github.com:nkbt/react-animation.git
 + 5de8fa2...be54b92 gh-pages -> gh-pages (forced update)
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.

C:\www\react-animation (master)
```

