### PR TITLE
Ignore sublime configuration files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,11 +1,18 @@
+/.*
+
 /bower_components/
+/bower.json
+
 /build/
 /coverage/
 /demos/
 /native/non-compiled.js
 /test/
-/.*
-/bower.json
+
 /karma.conf.js
-/server.js
 /webpack.*
+/server.js
+
+# sublime
+/*.sublime-project
+/*.sublime-workspace


### PR DESCRIPTION
Noticed that latest NPM package release (0.3.0) contains Sublime configuration files, which seems like got there accidentally. To prevent it further, it's better to ignore those files from adding to NPM package.