### PR TITLE
Switch to compare x with rest on errorMargin check

### DIFF
--- a/src/stepper.js
+++ b/src/stepper.js
@@ -25,7 +25,7 @@ export default function stepper(
   const newV = v + a * frameRate;
   const newX = x + newV * frameRate;
 
-  if (Math.abs(newV - v) < errorMargin && Math.abs(newX - x) < errorMargin) {
+  if (Math.abs(newV - v) < errorMargin && Math.abs(newX - destX) < errorMargin) {
     return [destX, 0];
   }
 

--- a/src/stepper.js
+++ b/src/stepper.js
@@ -1,5 +1,5 @@
 /* @flow */
-const errorMargin = 0.0001;
+const errorMargin = 0.001;
 
 export default function stepper(
   frameRate: number,
@@ -25,7 +25,7 @@ export default function stepper(
   const newV = v + a * frameRate;
   const newX = x + newV * frameRate;
 
-  if (Math.abs(newV - v) < errorMargin && Math.abs(newX - destX) < errorMargin) {
+  if (Math.abs(newV) < errorMargin && Math.abs(newX - destX) < errorMargin) {
     return [destX, 0];
   }
 


### PR DESCRIPTION
Looks like it's better to check x with rest value, not previous.
For example if errorMargin becomes a user parameter, there will situations with small velocity and small dx values but x is far from the rest.