### PR TITLE
Add MotionBoundary / externalRender which lets you skip unnecessary renders

### DIFF
--- a/demos/demo3-todomvc-list-transition/Demo.jsx
+++ b/demos/demo3-todomvc-list-transition/Demo.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {TransitionMotion, spring} from '../../src/react-motion';
+import {TransitionMotion, spring, MotionBoundary} from '../../src/react-motion';
 import presets from '../../src/presets';
 
 const Demo = React.createClass({
@@ -145,13 +145,14 @@ const Demo = React.createClass({
           <input className="toggle-all" type="checkbox" onChange={this.handleToggleAll} />
           <TransitionMotion defaultStyles={this.getDefaultValue()} styles={this.getEndValue()} willLeave={this.willLeave}
             willEnter={this.willEnter}>
-            {configs =>
+            {(configs, externalRender) =>
               <ul className="todo-list">
                 {Object.keys(configs).map(date => {
                   const config = configs[date];
                   const {data: {isDone, text}, ...style} = config;
                   return (
                     <li key={date} style={style} className={isDone ? 'completed' : ''}>
+                      <MotionBoundary externalRender={externalRender}>
                       <div className="view">
                         <input
                           className="toggle"
@@ -165,6 +166,7 @@ const Demo = React.createClass({
                           onClick={this.handleDestroy.bind(null, date)}
                         />
                       </div>
+                      </MotionBoundary>
                     </li>
                   );
                 })}

--- a/src/components.js
+++ b/src/components.js
@@ -68,11 +68,21 @@ export default function components(React) {
       };
     },
 
+    componentWillMount() {
+      this.externalRender = true;
+    },
+
+    componentDidUpdate() {
+      this.externalRender = false;
+    },
+
     componentDidMount() {
+      this.externalRender = false;
       this.startAnimating();
     },
 
     componentWillReceiveProps() {
+      this.externalRender = true;
       this.startAnimating();
     },
 
@@ -136,7 +146,7 @@ export default function components(React) {
 
     render() {
       const strippedStyle = stripStyle(this.state.currentStyle);
-      const renderedChildren = this.props.children(strippedStyle);
+      const renderedChildren = this.props.children(strippedStyle, this.externalRender);
       return renderedChildren && React.Children.only(renderedChildren);
     },
   });
@@ -172,11 +182,21 @@ export default function components(React) {
       };
     },
 
+    componentWillMount() {
+      this.externalRender = true;
+    },
+
+    componentDidUpdate() {
+      this.externalRender = false;
+    },
+
     componentDidMount() {
+      this.externalRender = false;
       this.startAnimating();
     },
 
     componentWillReceiveProps() {
+      this.externalRender = true;
       this.startAnimating();
     },
 
@@ -236,7 +256,7 @@ export default function components(React) {
 
     render() {
       const strippedStyle = this.state.currentStyles.map(stripStyle);
-      const renderedChildren = this.props.children(strippedStyle);
+      const renderedChildren = this.props.children(strippedStyle, this.externalRender);
       return renderedChildren && React.Children.only(renderedChildren);
     },
   });
@@ -315,11 +335,21 @@ export default function components(React) {
       };
     },
 
+    componentWillMount() {
+      this.externalRender = true;
+    },
+
+    componentDidUpdate() {
+      this.externalRender = false;
+    },
+
     componentDidMount() {
+      this.externalRender = false;
       this.startAnimating();
     },
 
     componentWillReceiveProps() {
+      this.externalRender = true;
       this.startAnimating();
     },
 
@@ -428,12 +458,26 @@ export default function components(React) {
 
     render() {
       const strippedStyle = mapObject(stripStyle, this.state.currentStyles);
-      const renderedChildren = this.props.children(strippedStyle);
+      const renderedChildren = this.props.children(strippedStyle, this.externalRender);
       return renderedChildren && React.Children.only(renderedChildren);
     },
   });
 
+  const MotionBoundary = React.createClass({
+    propTypes: {
+      externalRender: PropTypes.bool.isRequired,
+      children: PropTypes.node,
+    },
+    shouldComponentUpdate(nextProps) {
+      return nextProps.externalRender;
+    },
+    render() {
+      return this.props.children;
+    },
+  });
+
+
   const {Spring, TransitionSpring} = deprecatedSprings(React);
 
-  return {Spring, TransitionSpring, Motion, StaggeredMotion, TransitionMotion};
+  return {Spring, TransitionSpring, Motion, StaggeredMotion, TransitionMotion, MotionBoundary};
 }

--- a/src/react-motion.js
+++ b/src/react-motion.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import components from './components';
 
-export const {Spring, TransitionSpring, Motion, StaggeredMotion, TransitionMotion} = components(React);
+export const {Spring, TransitionSpring, Motion, StaggeredMotion, TransitionMotion, MotionBoundary} = components(React);
 export spring from './spring';
 export presets from './presets';
 import reorderKeys from './reorderKeys';


### PR DESCRIPTION
If the reason the subtree under the motion is rendered just because of the animation, stop rendering in the MotionBoundary, this significantly improves frame rate.
Added to Todo sample