### PR TITLE
Add /lib/.gitignore to fix build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ pids
 coverage
 node_modules
 bower_components
-lib
 
 .DS_Store
 

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*.js
+*.map
+# Except this file
+!.gitignore

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "start": "node server.js",
     "build-demos": "webpack",
     "lint": "eslint --ext .js,.jsx .",
-    "prerelease": "rm lib/* && babel src --out-dir lib && webpack --config webpack.prod.config.js",
+    "prerelease": "rm lib/*.js && babel src --out-dir lib && webpack --config webpack.prod.config.js",
     "test": "karma start ./karma.conf.js --single-run",
     "test:travis": "karma start ./karma.conf.js --single-run",
     "test:dev": "karma start ./karma.conf.js --no-single-run --auto-watch",


### PR DESCRIPTION
If you try to build currently from a fresh clone, you get:

```
rm: lib/*: No such file or directory
```

This fixes that by tracking an empty `lib` in git.