### PR TITLE
Update to support Flow 0.22.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 .*/node_modules/fbjs/lib/PromiseMap.js
 .*/node_modules/fbjs/lib/fetchWithRetries.js
+.*/test/.*
 
 [include]
 

--- a/src/Motion.js
+++ b/src/Motion.js
@@ -7,6 +7,7 @@ import defaultRaf from 'raf';
 import shouldStopAnimation from './shouldStopAnimation';
 import React, {PropTypes} from 'react';
 
+import type { Element as ReactElement } from 'react';
 import type {PlainStyle, Style, Velocity, MotionProps} from './Types';
 const msPerFrame = 1000 / 60;
 

--- a/src/StaggeredMotion.js
+++ b/src/StaggeredMotion.js
@@ -7,6 +7,7 @@ import defaultRaf from 'raf';
 import shouldStopAnimation from './shouldStopAnimation';
 import React, {PropTypes} from 'react';
 
+import type { Element as ReactElement } from 'react';
 import type {PlainStyle, Style, Velocity, StaggeredProps} from './Types';
 
 const msPerFrame = 1000 / 60;

--- a/src/TransitionMotion.js
+++ b/src/TransitionMotion.js
@@ -8,6 +8,7 @@ import defaultRaf from 'raf';
 import shouldStopAnimation from './shouldStopAnimation';
 import React, {PropTypes} from 'react';
 
+import type { Element as ReactElement } from 'react';
 import type {
   PlainStyle,
   Velocity,

--- a/src/Types.js
+++ b/src/Types.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import type { Element as ReactElement } from 'react';
 // === basic reused types ===
 // type of the second parameter of `spring(val, config)` all fields are optional
 export type SpringHelperConfig = {


### PR DESCRIPTION
Flow no longer globally recognizes internal React types.
Manually import type { Element as ReactElement } to squash Flow errors.
Also ignoring the test folders via flow config, they are causing superfluous warnings.