### PR TITLE
Try fixing souporserious/react-motion-ui-pack#41 by checking if unmounting is in progress.

### DIFF
--- a/src/TransitionMotion.js
+++ b/src/TransitionMotion.js
@@ -336,6 +336,9 @@ const TransitionMotion = React.createClass({
   },
 
   startAnimationIfNecessary(): void {
+    if (this.unmounting) {
+      return;
+    }
     // TODO: when config is {a: 10} and dest is {a: 10} do we raf once and
     // call cb? No, otherwise accidental parent rerender causes cb trigger
     this.animationID = defaultRaf(() => {
@@ -501,6 +504,7 @@ const TransitionMotion = React.createClass({
   },
 
   componentWillUnmount() {
+    this.unmounting = true;
     if (this.animationID != null) {
       defaultRaf.cancel(this.animationID);
       this.animationID = null;


### PR DESCRIPTION
This fixes the TransitionMotion component not unmounting nicely. I am not 100% this is the right way to do this or why I am having so much trouble reproducing this using react-motion only.