### PR TITLE
in TransitionMotion allow number proptype for "key"

### DIFF
--- a/src/TransitionMotion.js
+++ b/src/TransitionMotion.js
@@ -185,14 +185,20 @@ type TransitionMotionState = {
 const TransitionMotion = React.createClass({
   propTypes: {
     defaultStyles: PropTypes.arrayOf(PropTypes.shape({
-      key: PropTypes.string.isRequired,
+      key: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+      ]).isRequired,
       data: PropTypes.any,
       style: PropTypes.objectOf(PropTypes.number).isRequired,
     })),
     styles: PropTypes.oneOfType([
       PropTypes.func,
       PropTypes.arrayOf(PropTypes.shape({
-        key: PropTypes.string.isRequired,
+        key: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number
+        ]).isRequired,
         data: PropTypes.any,
         style: PropTypes.objectOf(PropTypes.oneOfType([
           PropTypes.number,

--- a/test/TransitionMotion-test.js
+++ b/test/TransitionMotion-test.js
@@ -69,8 +69,8 @@ describe('TransitionMotion', () => {
         return this.state.kill
           ? null
           : <TransitionMotion
-              defaultStyles={[{key: '1', style: {x: 0}}]}
-              styles={() => [{key: '1', style: {x: spring(10)}}]}>
+              defaultStyles={[{key: 1, style: {x: 0}}]}
+              styles={() => [{key: 1, style: {x: spring(10)}}]}>
               {() => null}
             </TransitionMotion>;
       },


### PR DESCRIPTION
The update makes it so that a key can be set as a number on styles and defaultStyles like so:

`<TransitionMotion
    defaultStyles={[{key: 1, style: {x: 0}}]}
    styles={() => [{key: 1, style: {x: spring(10)}}]}>
</TransitionMotion>`