### PR TITLE
Fix flow for TransitionMotion.unmounting

### DIFF
--- a/src/TransitionMotion.js
+++ b/src/TransitionMotion.js
@@ -266,6 +266,7 @@ const TransitionMotion = React.createClass({
     };
   },
 
+  unmounting: (false: boolean),
   animationID: (null: ?number),
   prevTime: 0,
   accumulatedTime: 0,


### PR DESCRIPTION
Since 0.4.4 flowtype complains
```
node_modules/react-motion/src/TransitionMotion.js:508
508:     this.unmounting = true;
              ^^^^^^^^^^ property `unmounting`. Property not found in
186: const TransitionMotion = React.createClass({
                              ^ React component
```