### PR TITLE
Fix Flow ReactElement errors

### DIFF
--- a/src/Motion.js
+++ b/src/Motion.js
@@ -223,7 +223,7 @@ const Motion = React.createClass({
     }
   },
 
-  render(): ReactElement {
+  render(): React$Element<*> {
     const renderedChildren = this.props.children(this.state.currentStyle);
     return renderedChildren && React.Children.only(renderedChildren);
   },

--- a/src/StaggeredMotion.js
+++ b/src/StaggeredMotion.js
@@ -244,7 +244,7 @@ const StaggeredMotion = React.createClass({
     }
   },
 
-  render(): ReactElement {
+  render(): React$Element<*> {
     const renderedChildren = this.props.children(this.state.currentStyles);
     return renderedChildren && React.Children.only(renderedChildren);
   },

--- a/src/TransitionMotion.js
+++ b/src/TransitionMotion.js
@@ -513,7 +513,7 @@ const TransitionMotion = React.createClass({
     }
   },
 
-  render(): ReactElement {
+  render(): React$Element<*> {
     const hydratedStyles = rehydrateStyles(
       this.state.mergedPropsStyles,
       this.unreadPropStyles,

--- a/src/Types.js
+++ b/src/Types.js
@@ -28,7 +28,7 @@ export type Velocity = {[key: string]: number};
 export type MotionProps = {
   defaultStyle?: PlainStyle,
   style: Style,
-  children: (interpolatedStyle: PlainStyle) => ReactElement,
+  children: (interpolatedStyle: PlainStyle) => React$Element<*>,
   onRest?: () => void,
 };
 
@@ -36,7 +36,7 @@ export type MotionProps = {
 export type StaggeredProps = {
   defaultStyles?: Array<PlainStyle>,
   styles: (previousInterpolatedStyles: ?Array<PlainStyle>) => Array<Style>,
-  children: (interpolatedStyles: Array<PlainStyle>) => ReactElement,
+  children: (interpolatedStyles: Array<PlainStyle>) => React$Element<*>,
 };
 
 // === TransitionMotion ===
@@ -57,7 +57,7 @@ export type WillLeave = (styleThatLeft: TransitionStyle) => ?Style;
 export type TransitionProps = {
   defaultStyles?: Array<TransitionPlainStyle>,
   styles: Array<TransitionStyle> | (previousInterpolatedStyles: ?Array<TransitionPlainStyle>) => Array<TransitionStyle>,
-  children: (interpolatedStyles: Array<TransitionPlainStyle>) => ReactElement,
+  children: (interpolatedStyles: Array<TransitionPlainStyle>) => React$Element<*>,
   willEnter?: WillEnter,
   willLeave?: WillLeave,
 };


### PR DESCRIPTION
In later versions of flow, it requires that generic types have their
type parameters specified. All of the `ReactElement` declarations were
throwing an error saying these needed to be specified.

This change updates `ReactElement` to `React$Element<*>`