### PR TITLE
Add didLeave method to <TransitionMotion />

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,11 @@ Optional. Defaults to `() => null`. **The magic sauce property**.
 
 - Return: `null` to indicate you want the `TransitionStyle` gone immediately. A `Style` object to indicate you want to reach transition to the specified value(s) before killing the `TransitionStyle`.
 
+##### - didLeave?: (styleThatLeft: `{key: string, data?: any}`) => void
+Optional. Defaults to `() => {}`.
+
+- `styleThatLeft`: the `{key:..., data:...}` that was removed after the finished transition.
+
 ##### - willEnter?: (styleThatEntered: TransitionStyle) => PlainStyle
 Optional. Defaults to `styleThatEntered => stripStyle(styleThatEntered.style)`. Where `stripStyle` turns `{x: spring(10), y: spring(20)}` into `{x: 10, y: 20}`.
 

--- a/src/Types.js
+++ b/src/Types.js
@@ -60,6 +60,7 @@ export type TransitionPlainStyle = {
 };
 export type WillEnter = (styleThatEntered: TransitionStyle) => PlainStyle;
 export type WillLeave = (styleThatLeft: TransitionStyle) => ?Style;
+export type DidLeave = (styleThatLeft: { key: string, data?: any }) => void;
 
 export type TransitionProps = {
   defaultStyles?: Array<TransitionPlainStyle>,

--- a/test/TransitionMotion-test.js
+++ b/test/TransitionMotion-test.js
@@ -200,6 +200,44 @@ describe('TransitionMotion', () => {
     ]);
   });
 
+  it('should invoke didLeave in last frame', () => {
+    let count = [];
+    let setState = () => {};
+    const App = React.createClass({
+      getInitialState() {
+        return {
+          val: [{key: '1', style: {x: spring(10)}}],
+        };
+      },
+      componentWillMount() {
+        setState = this.setState.bind(this);
+      },
+      render() {
+        return (
+          <TransitionMotion
+            styles={this.state.val}
+            willEnter={() => ({x: 0})}
+            willLeave={() => ({x: spring(0)})}
+            didLeave={(a) => { count.push(a); }}>
+            {() => {
+              return null;
+            }}
+          </TransitionMotion>
+        );
+      },
+    });
+    TestUtils.renderIntoDocument(<App />);
+
+    expect(count).toEqual([]);
+    setState({
+      val: [{key: '2', style: {x: 10}}],
+    });
+    mockRaf.step(999);
+    expect(count).toEqual([
+      {key: '1', data: undefined},
+    ]);
+  });
+
   it('should work with nested TransitionMotions', () => {
     let count = [];
     const App = React.createClass({

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,3 @@
-const testsContext = require.context('./', true, /\-test\.js$/);
+const testsContext = require.context('./', true, /-test\.js$/);
 
 testsContext.keys().forEach(testsContext);


### PR DESCRIPTION
Had a case where the index of each element was essential for correct visual representation. `didLeave` can be used to keep track of what elements `<TransitionMotion />` is still animating.

Can also be used as the `onRest` equivalent for `<TransitionMotion />`.