### PR TITLE
Performance optimisation for draggable list demo

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
     "no-nested-ternary": 0,
     "prefer-const": 0,
     "no-multiple-empty-lines": 0,
+    "no-useless-escape": 0,
 
     "react/no-did-mount-set-state": 2,
     "react/no-multi-comp": 0,

--- a/demos/demo8-draggable-list/Demo.jsx
+++ b/demos/demo8-draggable-list/Demo.jsx
@@ -55,10 +55,16 @@ const Demo = React.createClass({
 
   handleMouseMove({pageY}) {
     const {isPressed, delta, order, lastPressed} = this.state;
+
     if (isPressed) {
       const mouse = pageY - delta;
       const row = clamp(Math.round(mouse / 100), 0, itemsCount - 1);
-      const newOrder = reinsert(order, order.indexOf(lastPressed), row);
+      let newOrder = order;
+
+      if (row !== order.indexOf(lastPressed)){
+        newOrder = reinsert(order, order.indexOf(lastPressed), row);
+      }
+
       this.setState({mouse: mouse, order: newOrder});
     }
   },


### PR DESCRIPTION
Issue - Originally on every mouse move event the reinsert function was called to reorder list item positions. 

Fix - Added an if clause to ensure that "order" state items are only reordered when positional changes actually occur in the DOM.
