### PR TITLE
Make children prop type optional

### DIFF
--- a/src/Types.js
+++ b/src/Types.js
@@ -35,7 +35,7 @@ export type Velocity = {[key: string]: number};
 export type MotionProps = {
   defaultStyle?: PlainStyle,
   style: Style,
-  children: (interpolatedStyle: PlainStyle) => ReactElement,
+  children?: (interpolatedStyle: PlainStyle) => ReactElement,
   onRest?: () => void,
 };
 
@@ -43,7 +43,7 @@ export type MotionProps = {
 export type StaggeredProps = {
   defaultStyles?: Array<PlainStyle>,
   styles: (previousInterpolatedStyles: ?Array<PlainStyle>) => Array<Style>,
-  children: (interpolatedStyles: Array<PlainStyle>) => ReactElement,
+  children?: (interpolatedStyles: Array<PlainStyle>) => ReactElement,
 };
 
 // === TransitionMotion ===
@@ -65,7 +65,7 @@ export type DidLeave = (styleThatLeft: { key: string, data?: any }) => void;
 export type TransitionProps = {
   defaultStyles?: Array<TransitionPlainStyle>,
   styles: Array<TransitionStyle> | (previousInterpolatedStyles: ?Array<TransitionPlainStyle>) => Array<TransitionStyle>,
-  children: (interpolatedStyles: Array<TransitionPlainStyle>) => ReactElement,
+  children?: (interpolatedStyles: Array<TransitionPlainStyle>) => ReactElement,
   willEnter?: WillEnter,
   willLeave?: WillLeave,
 };


### PR DESCRIPTION
A bug in flow (https://github.com/facebook/flow/issues/1964) prevents it checking in it's children prop has been set in jsx. You can make flow ignorant to this prop by setting it as optional.

Addresses #375