### PR TITLE
Unmounted component setState fix

### DIFF
--- a/src/TransitionMotion.js
+++ b/src/TransitionMotion.js
@@ -342,12 +342,13 @@ const TransitionMotion = React.createClass({
   },
 
   startAnimationIfNecessary(): void {
-    if (this.unmounting) {
-      return;
-    }
     // TODO: when config is {a: 10} and dest is {a: 10} do we raf once and
     // call cb? No, otherwise accidental parent rerender causes cb trigger
     this.animationID = defaultRaf((timestamp) => {
+      if (this.unmounting) {
+        return;
+      }
+
       const propStyles = this.props.styles;
       let destStyles: Array<TransitionStyle> = typeof propStyles === 'function'
         ? propStyles(rehydrateStyles(

--- a/src/TransitionMotion.js
+++ b/src/TransitionMotion.js
@@ -342,6 +342,10 @@ const TransitionMotion = React.createClass({
   },
 
   startAnimationIfNecessary(): void {
+    if (this.unmounting) {
+      return;
+    }
+
     // TODO: when config is {a: 10} and dest is {a: 10} do we raf once and
     // call cb? No, otherwise accidental parent rerender causes cb trigger
     this.animationID = defaultRaf((timestamp) => {


### PR DESCRIPTION
This code in `TransitionMotion` was a source of bug for us in testing. 

```js
    if (this.unmounting) {
        return;
    }
    // TODO: when config is {a: 10} and dest is {a: 10} do we raf once and
    // call cb? No, otherwise accidental parent rerender causes cb trigger
    this.animationID = defaultRaf((timestamp) => {
      const propStyles = this.props.styles;
      ...
      this.setState({
        currentStyles: newCurrentStyles,
        currentVelocities: newCurrentVelocities,
        lastIdealStyles: newLastIdealStyles,
        lastIdealVelocities: newLastIdealVelocities,
        mergedPropsStyles: newMergedPropsStyles,
      });
      ...
    }
```

The problem is that if execution passes the conditional `if (this.unmounting)`, then executes async `defaultRaf` and after that component unmounts and after that the callback of `defaultRaf` is called, then `setState` will be called on unmounted component.

This fix solves the problem.
