### PR TITLE
Fix link to TypeScript types

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Exports:
 
 [Here](https://github.com/chenglou/react-motion/blob/9cb90eca20ecf56e77feb816d101a4a9110c7d70/src/Types.js)'s the well-annotated public [Flow type](http://flowtype.org) definition file (you don't have to use Flow with React-motion, but the types help document the API below).
 
-P.S. using TypeScript? [Here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/react-motion/index.d.ts) are the React-motion TypeScript definitions!
+P.S. using TypeScript? [Here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-motion/index.d.ts) are the React-motion TypeScript definitions!
 
 ---
 


### PR DESCRIPTION
Typings are now nested under the "/types" directory. Fixes #442