### PR TITLE
Migrated deprecated React.PropTypes and React.createClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ Fortunately, `TransitionMotion` has kept `c` around and still passes it into the
 This time, when mapping through the two remaining interpolated styles, you'll produce only two components. `c` is gone for real.
 
 ```jsx
-const Demo = React.createClass({
+import createReactClass from 'create-react-class';
+
+const Demo = createReactClass({
   getInitialState() {
     return {
       items: [{key: 'a', size: 10}, {key: 'b', size: 20}, {key: 'c', size: 30}],

--- a/demos/demo0-simple-transition/Demo.jsx
+++ b/demos/demo0-simple-transition/Demo.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {Motion, spring} from '../../src/react-motion';
 
-const Demo = React.createClass({
+const Demo = createReactClass({
   getInitialState() {
     return {open: false};
   },

--- a/demos/demo1-chat-heads/Demo.jsx
+++ b/demos/demo1-chat-heads/Demo.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {StaggeredMotion, spring, presets} from '../../src/react-motion';
 import range from 'lodash.range';
 
-const Demo = React.createClass({
+const Demo = createReactClass({
   getInitialState() {
     return {x: 250, y: 300};
   },

--- a/demos/demo2-draggable-balls/Demo.jsx
+++ b/demos/demo2-draggable-balls/Demo.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {Motion, spring} from '../../src/react-motion';
 import range from 'lodash.range';
 
@@ -28,7 +29,7 @@ const layout = range(count).map(n => {
   return [width * col, height * row];
 });
 
-const Demo = React.createClass({
+const Demo = createReactClass({
   getInitialState() {
     return {
       mouseXY: [0, 0],

--- a/demos/demo3-todomvc-list-transition/Demo.jsx
+++ b/demos/demo3-todomvc-list-transition/Demo.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {TransitionMotion, spring, presets} from '../../src/react-motion';
 
-const Demo = React.createClass({
+const Demo = createReactClass({
   getInitialState() {
     return {
       todos: [

--- a/demos/demo4-photo-gallery/Demo.jsx
+++ b/demos/demo4-photo-gallery/Demo.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {Motion, spring} from '../../src/react-motion';
 
 const springSettings = {stiffness: 170, damping: 26};
 const NEXT = 'show-next';
 
-const Demo = React.createClass({
+const Demo = createReactClass({
   getInitialState() {
     return {
       photos: [[500, 350], [800, 600], [800, 400], [700, 500], [200, 650], [600, 600]],

--- a/demos/demo5-spring-parameters-chooser/Demo.jsx
+++ b/demos/demo5-spring-parameters-chooser/Demo.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {Motion, spring} from '../../src/react-motion';
 import range from 'lodash.range';
 
@@ -6,7 +7,7 @@ const gridWidth = 150;
 const gridHeight = 150;
 const grid = range(4).map(() => range(6));
 
-const Demo = React.createClass({
+const Demo = createReactClass({
   getInitialState() {
     return {
       delta: [0, 0],

--- a/demos/demo7-water-ripples/Demo.jsx
+++ b/demos/demo7-water-ripples/Demo.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {TransitionMotion, spring} from '../../src/react-motion';
 
 const leavingSpringConfig = {stiffness: 60, damping: 15};
-const Demo = React.createClass({
+const Demo = createReactClass({
   getInitialState() {
     return {mouse: [], now: 't' + 0};
   },

--- a/demos/demo8-draggable-list/Demo.jsx
+++ b/demos/demo8-draggable-list/Demo.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {Motion, spring} from '../../src/react-motion';
 import range from 'lodash.range';
 
@@ -17,7 +18,7 @@ function clamp(n, min, max) {
 const springConfig = {stiffness: 300, damping: 50};
 const itemsCount = 4;
 
-const Demo = React.createClass({
+const Demo = createReactClass({
   getInitialState() {
     return {
       topDeltaY: 0,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,9 @@
   "author": "chenglou",
   "license": "MIT",
   "dependencies": {
+    "create-react-class": "^15.5.2",
     "performance-now": "^0.2.0",
+    "prop-types": "^15.5.8",
     "raf": "^3.1.0"
   }
 }

--- a/src/Motion.js
+++ b/src/Motion.js
@@ -5,7 +5,9 @@ import stepper from './stepper';
 import defaultNow from 'performance-now';
 import defaultRaf from 'raf';
 import shouldStopAnimation from './shouldStopAnimation';
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 import type {ReactElement, PlainStyle, Style, Velocity, MotionProps} from './Types';
 
@@ -18,7 +20,7 @@ type MotionState = {
   lastIdealVelocity: Velocity,
 };
 
-const Motion = React.createClass({
+const Motion = createReactClass({
   propTypes: {
     // TOOD: warn against putting a config in here
     defaultStyle: PropTypes.objectOf(PropTypes.number),

--- a/src/StaggeredMotion.js
+++ b/src/StaggeredMotion.js
@@ -5,7 +5,9 @@ import stepper from './stepper';
 import defaultNow from 'performance-now';
 import defaultRaf from 'raf';
 import shouldStopAnimation from './shouldStopAnimation';
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 import type {ReactElement, PlainStyle, Style, Velocity, StaggeredProps} from './Types';
 
@@ -31,7 +33,7 @@ function shouldStopAnimationAll(
   return true;
 }
 
-const StaggeredMotion = React.createClass({
+const StaggeredMotion = createReactClass({
   propTypes: {
     // TOOD: warn against putting a config in here
     defaultStyles: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.number)),

--- a/src/TransitionMotion.js
+++ b/src/TransitionMotion.js
@@ -6,7 +6,9 @@ import mergeDiff from './mergeDiff';
 import defaultNow from 'performance-now';
 import defaultRaf from 'raf';
 import shouldStopAnimation from './shouldStopAnimation';
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 import type {
   ReactElement,
@@ -185,7 +187,7 @@ type TransitionMotionState = {
   mergedPropsStyles: Array<TransitionStyle>,
 };
 
-const TransitionMotion = React.createClass({
+const TransitionMotion = createReactClass({
   propTypes: {
     defaultStyles: PropTypes.arrayOf(PropTypes.shape({
       key: PropTypes.string.isRequired,
@@ -248,7 +250,7 @@ const TransitionMotion = React.createClass({
       ? destStyles.map(s => mapToZero(s.style))
       : defaultStyles.map(s => mapToZero(s.style));
     const [mergedPropsStyles, currentStyles, currentVelocities, lastIdealStyles, lastIdealVelocities] = mergeAndSync(
-      // Because this is an old-style React.createClass component, Flow doesn't
+      // Because this is an old-style createReactClass component, Flow doesn't
       // understand that the willEnter and willLeave props have default values
       // and will always be present.
       (willEnter: any),

--- a/test/Motion-test.js
+++ b/test/Motion-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {spring} from '../src/react-motion';
 import createMockRaf from './createMockRaf';
 import TestUtils from 'react-addons-test-utils';
@@ -23,7 +24,7 @@ describe('animation loop', () => {
 
   it('should interpolate correctly when the timer is perfect', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <Motion defaultStyle={{a: 0}} style={{a: spring(10)}}>
@@ -51,7 +52,7 @@ describe('animation loop', () => {
 
   it('should work with negative numbers', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <Motion defaultStyle={{a: -10}} style={{a: spring(-100)}}>
@@ -78,7 +79,7 @@ describe('animation loop', () => {
 
   it('should interpolate correctly when the timer is imperfect', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <Motion defaultStyle={{a: 0}} style={{a: spring(10)}}>
@@ -139,7 +140,7 @@ describe('Motion', () => {
   });
 
   it('should allow returning null from children function', () => {
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         // shouldn't throw here
         return <Motion style={{a: 0}}>{() => null}</Motion>;
@@ -151,7 +152,7 @@ describe('Motion', () => {
   it('should not throw on unmount', () => {
     spyOn(console, 'error');
     let kill = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {kill: false};
       },
@@ -173,7 +174,7 @@ describe('Motion', () => {
 
   it('should allow a defaultStyle', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <Motion defaultStyle={{a: 0}} style={{a: spring(10)}}>
@@ -200,7 +201,7 @@ describe('Motion', () => {
 
   it('should accept different spring configs', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <Motion
@@ -232,7 +233,7 @@ describe('Motion', () => {
 
   it('should interpolate many values', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <Motion
@@ -262,7 +263,7 @@ describe('Motion', () => {
 
   it('should work with nested Motions', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <Motion defaultStyle={{owner: 0}} style={{owner: spring(10)}}>
@@ -312,7 +313,7 @@ describe('Motion', () => {
 
   it('should reach destination value', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <Motion defaultStyle={{a: 0}} style={{a: spring(400)}}>
@@ -342,7 +343,7 @@ describe('Motion', () => {
   it('should support jumping to value', () => {
     let count = [];
     let setState = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {p: false};
       },
@@ -392,7 +393,7 @@ describe('Motion', () => {
     const onRest = createSpy('onRest');
     let result = 0;
 
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <Motion
@@ -425,7 +426,7 @@ describe('Motion', () => {
     let resultA = 0;
     let resultB = 0;
 
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <Motion
@@ -463,7 +464,7 @@ describe('Motion', () => {
 
     let setState;
 
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {a: spring(0)};
       },
@@ -494,7 +495,7 @@ describe('Motion', () => {
   it('should behave well when many owner updates come in-between rAFs', () => {
     let count = [];
     let setState = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {a: spring(0)};
       },

--- a/test/StaggeredMotion-test.js
+++ b/test/StaggeredMotion-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {spring} from '../src/react-motion';
 import createMockRaf from './createMockRaf';
 import TestUtils from 'react-addons-test-utils';
@@ -18,7 +19,7 @@ describe('StaggeredMotion', () => {
   });
 
   it('should allow returning null from children function', () => {
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         // shouldn't throw here
         return (
@@ -34,7 +35,7 @@ describe('StaggeredMotion', () => {
   it('should not throw on unmount', () => {
     spyOn(console, 'error');
     let kill = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {kill: false};
       },
@@ -58,7 +59,7 @@ describe('StaggeredMotion', () => {
 
   it('should allow a defaultStyles', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <StaggeredMotion
@@ -87,7 +88,7 @@ describe('StaggeredMotion', () => {
 
   it('should accept different spring configs', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <StaggeredMotion
@@ -119,7 +120,7 @@ describe('StaggeredMotion', () => {
 
   it('should interpolate many values while staggering', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <StaggeredMotion
@@ -153,7 +154,7 @@ describe('StaggeredMotion', () => {
 
   it('should work with nested Motions', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <StaggeredMotion defaultStyles={[{owner: 0}]} styles={() => [{owner: spring(10)}]}>
@@ -205,7 +206,7 @@ describe('StaggeredMotion', () => {
   // maybe shouldStopAnimation logic has a flaw
   it('should reach destination value', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <StaggeredMotion
@@ -241,7 +242,7 @@ describe('StaggeredMotion', () => {
   it('should support jumping to value', () => {
     let count = [];
     let setState = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {p: false};
       },
@@ -290,7 +291,7 @@ describe('StaggeredMotion', () => {
   it('should behave well when many owner updates come in-between rAFs', () => {
     let count = [];
     let setState = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {a: spring(0)};
       },

--- a/test/TransitionMotion-test.js
+++ b/test/TransitionMotion-test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {spring} from '../src/react-motion';
 import createMockRaf from './createMockRaf';
 import TestUtils from 'react-addons-test-utils';
@@ -18,7 +19,7 @@ describe('TransitionMotion', () => {
   });
 
   it('should allow returning null from children function', () => {
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         // shouldn't throw here
         return <TransitionMotion styles={[{key: '1', style: {}}]}>{() => null}</TransitionMotion>;
@@ -30,7 +31,7 @@ describe('TransitionMotion', () => {
   it('should not throw on unmount', () => {
     spyOn(console, 'error');
     let kill = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {kill: false};
       },
@@ -58,7 +59,7 @@ describe('TransitionMotion', () => {
     // similar as above test
     spyOn(console, 'error');
     let kill = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {kill: false};
       },
@@ -84,7 +85,7 @@ describe('TransitionMotion', () => {
 
   it('should allow a defaultStyles', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <TransitionMotion
@@ -114,7 +115,7 @@ describe('TransitionMotion', () => {
 
   it('should accept different spring configs', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <TransitionMotion
@@ -148,7 +149,7 @@ describe('TransitionMotion', () => {
 
   it('should interpolate many values', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <TransitionMotion
@@ -203,7 +204,7 @@ describe('TransitionMotion', () => {
   it('should invoke didLeave in last frame', () => {
     let count = [];
     let setState = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {
           val: [{key: '1', style: {x: spring(10)}}],
@@ -240,7 +241,7 @@ describe('TransitionMotion', () => {
 
   it('should work with nested TransitionMotions', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <TransitionMotion
@@ -297,7 +298,7 @@ describe('TransitionMotion', () => {
 
   it('should reach destination value', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <TransitionMotion
@@ -329,7 +330,7 @@ describe('TransitionMotion', () => {
   it('should support jumping to value', () => {
     let count = [];
     let setState = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {p: false};
       },
@@ -379,7 +380,7 @@ describe('TransitionMotion', () => {
   it('should behave well when many owner updates come in-between rAFs', () => {
     let count = [];
     let setState = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {
           val: [{key: '1', style: {x: spring(0)}}],
@@ -456,7 +457,7 @@ describe('TransitionMotion', () => {
   it('should behave well when many owner styles function updates come in-between rAFs', () => {
     let count = [];
     let setState = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {
           val: [{key: '1', style: {x: spring(0)}}],
@@ -532,7 +533,7 @@ describe('TransitionMotion', () => {
 
   it('should transition things in/out at the beginning', () => {
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <TransitionMotion
@@ -590,7 +591,7 @@ describe('TransitionMotion', () => {
   it('should eliminate things in/out at the beginning', () => {
     // similar to previous test, but without willEnter/leave
     let count = [];
-    const App = React.createClass({
+    const App = createReactClass({
       render() {
         return (
           <TransitionMotion
@@ -634,7 +635,7 @@ describe('TransitionMotion', () => {
   it('should carry around the ignored values', () => {
     let count = [];
     let setState = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {
           val: [
@@ -738,7 +739,7 @@ describe('TransitionMotion', () => {
     let count = [];
     let prevValues = [];
     let setState = () => {};
-    const App = React.createClass({
+    const App = createReactClass({
       getInitialState() {
         return {
           val: [


### PR DESCRIPTION
Fixes #445

I think we should migrate to the es6 `class` syntax and stop using `React.createClass`, but that would be another step. For now just created this PR, so people stop having deprecation warnings after migration to React v15.5. 

If you feel the same about `class`, I'll create an issue about it, so the matter won't get forgotten and neglected.