### PR TITLE
Update deprecated 'create-react-class' dependencies in tests to ES6 classes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "build/react-motion.map"
   ],
   "dependencies": {
-    "react": ">=0.13.2 || ^0.14 || ^15.0.0"
+    "react": "^0.14.9 || ^15.3.0"
   },
   "keywords": [
     "react",

--- a/test/Motion-test.js
+++ b/test/Motion-test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import {spring} from '../src/react-motion';
 import createMockRaf from './createMockRaf';
 import TestUtils from 'react-addons-test-utils';
@@ -24,7 +23,7 @@ describe('animation loop', () => {
 
   it('should interpolate correctly when the timer is perfect', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <Motion defaultStyle={{a: 0}} style={{a: spring(10)}}>
@@ -34,8 +33,8 @@ describe('animation loop', () => {
             }}
           </Motion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([0]);
@@ -52,7 +51,7 @@ describe('animation loop', () => {
 
   it('should work with negative numbers', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <Motion defaultStyle={{a: -10}} style={{a: spring(-100)}}>
@@ -62,8 +61,8 @@ describe('animation loop', () => {
             }}
           </Motion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     mockRaf.step(5);
@@ -79,7 +78,7 @@ describe('animation loop', () => {
 
   it('should interpolate correctly when the timer is imperfect', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <Motion defaultStyle={{a: 0}} style={{a: spring(10)}}>
@@ -89,8 +88,8 @@ describe('animation loop', () => {
             }}
           </Motion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([0]);
@@ -140,31 +139,35 @@ describe('Motion', () => {
   });
 
   it('should allow returning null from children function', () => {
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         // shouldn't throw here
         return <Motion style={{a: 0}}>{() => null}</Motion>;
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
   });
 
   it('should not throw on unmount', () => {
     spyOn(console, 'error');
     let kill = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {kill: false};
-      },
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
+          kill: false,
+        };
+      }
       componentWillMount() {
         kill = () => this.setState({kill: true});
-      },
+      }
       render() {
         return this.state.kill
           ? null
           : <Motion defaultStyle={{a: 0}} style={{a: spring(10)}}>{() => null}</Motion>;
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
     mockRaf.step(2);
     kill();
@@ -174,7 +177,7 @@ describe('Motion', () => {
 
   it('should allow a defaultStyle', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <Motion defaultStyle={{a: 0}} style={{a: spring(10)}}>
@@ -184,8 +187,8 @@ describe('Motion', () => {
             }}
           </Motion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([0]);
@@ -201,7 +204,7 @@ describe('Motion', () => {
 
   it('should accept different spring configs', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <Motion
@@ -213,8 +216,8 @@ describe('Motion', () => {
             }}
           </Motion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     mockRaf.step(99);
@@ -233,7 +236,7 @@ describe('Motion', () => {
 
   it('should interpolate many values', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <Motion
@@ -245,8 +248,8 @@ describe('Motion', () => {
             }}
           </Motion>
         );
-      },
-    });
+      }
+    }
 
     TestUtils.renderIntoDocument(<App />);
 
@@ -263,7 +266,7 @@ describe('Motion', () => {
 
   it('should work with nested Motions', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <Motion defaultStyle={{owner: 0}} style={{owner: spring(10)}}>
@@ -280,8 +283,8 @@ describe('Motion', () => {
             }}
           </Motion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([0, 10]);
@@ -313,7 +316,7 @@ describe('Motion', () => {
 
   it('should reach destination value', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <Motion defaultStyle={{a: 0}} style={{a: spring(400)}}>
@@ -323,8 +326,8 @@ describe('Motion', () => {
             }}
           </Motion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([0]);
@@ -343,13 +346,17 @@ describe('Motion', () => {
   it('should support jumping to value', () => {
     let count = [];
     let setState = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {p: false};
-      },
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
+          p: false,
+        };
+      }
       componentWillMount() {
         setState = this.setState.bind(this);
-      },
+      }
       render() {
         return (
           <Motion style={{a: this.state.p ? 400 : spring(0)}}>
@@ -359,8 +366,8 @@ describe('Motion', () => {
             }}
           </Motion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([0]);
@@ -393,7 +400,7 @@ describe('Motion', () => {
     const onRest = createSpy('onRest');
     let result = 0;
 
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <Motion
@@ -409,8 +416,8 @@ describe('Motion', () => {
             }
           </Motion>
         );
-      },
-    });
+      }
+    }
 
     TestUtils.renderIntoDocument(<App />);
 
@@ -426,7 +433,7 @@ describe('Motion', () => {
     let resultA = 0;
     let resultB = 0;
 
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <Motion
@@ -446,8 +453,8 @@ describe('Motion', () => {
             }
           </Motion>
         );
-      },
-    });
+      }
+    }
 
     TestUtils.renderIntoDocument(<App />);
 
@@ -464,13 +471,17 @@ describe('Motion', () => {
 
     let setState;
 
-    const App = createReactClass({
-      getInitialState() {
-        return {a: spring(0)};
-      },
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
+          a: spring(0),
+        };
+      }
       componentWillMount() {
         setState = this.setState.bind(this);
-      },
+      }
       render() {
         return (
           <Motion
@@ -481,8 +492,8 @@ describe('Motion', () => {
             {() => null}
           </Motion>
         );
-      },
-    });
+      }
+    }
 
     TestUtils.renderIntoDocument(<App />);
     mockRaf.step();
@@ -495,13 +506,17 @@ describe('Motion', () => {
   it('should behave well when many owner updates come in-between rAFs', () => {
     let count = [];
     let setState = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {a: spring(0)};
-      },
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
+          a: spring(0),
+        };
+      }
       componentWillMount() {
         setState = this.setState.bind(this);
-      },
+      }
       render() {
         return (
           <Motion style={this.state}>
@@ -511,8 +526,8 @@ describe('Motion', () => {
             }}
           </Motion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([{a: 0}]);

--- a/test/Motion-test.js
+++ b/test/Motion-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import React from 'react';
 import {spring} from '../src/react-motion';
 import createMockRaf from './createMockRaf';

--- a/test/StaggeredMotion-test.js
+++ b/test/StaggeredMotion-test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import {spring} from '../src/react-motion';
 import createMockRaf from './createMockRaf';
 import TestUtils from 'react-addons-test-utils';
@@ -19,7 +18,7 @@ describe('StaggeredMotion', () => {
   });
 
   it('should allow returning null from children function', () => {
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         // shouldn't throw here
         return (
@@ -27,29 +26,33 @@ describe('StaggeredMotion', () => {
             {() => null}
           </StaggeredMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
   });
 
   it('should not throw on unmount', () => {
     spyOn(console, 'error');
     let kill = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {kill: false};
-      },
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
+          kill: false,
+        };
+      }
       componentWillMount() {
         kill = () => this.setState({kill: true});
-      },
+      }
       render() {
         return this.state.kill
           ? null
           : <StaggeredMotion defaultStyles={[{a: 0}]} styles={() => [{a: spring(10)}]}>
               {() => null}
             </StaggeredMotion>;
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
     mockRaf.step(2);
     kill();
@@ -59,7 +62,7 @@ describe('StaggeredMotion', () => {
 
   it('should allow a defaultStyles', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <StaggeredMotion
@@ -71,8 +74,8 @@ describe('StaggeredMotion', () => {
             }}
           </StaggeredMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([0]);
@@ -88,7 +91,7 @@ describe('StaggeredMotion', () => {
 
   it('should accept different spring configs', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <StaggeredMotion
@@ -100,8 +103,8 @@ describe('StaggeredMotion', () => {
             }}
           </StaggeredMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     mockRaf.step(99);
@@ -120,7 +123,7 @@ describe('StaggeredMotion', () => {
 
   it('should interpolate many values while staggering', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <StaggeredMotion
@@ -136,8 +139,8 @@ describe('StaggeredMotion', () => {
             }}
           </StaggeredMotion>
         );
-      },
-    });
+      }
+    }
 
     TestUtils.renderIntoDocument(<App />);
 
@@ -154,7 +157,7 @@ describe('StaggeredMotion', () => {
 
   it('should work with nested Motions', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <StaggeredMotion defaultStyles={[{owner: 0}]} styles={() => [{owner: spring(10)}]}>
@@ -171,8 +174,8 @@ describe('StaggeredMotion', () => {
             }}
           </StaggeredMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([0, 10]);
@@ -206,7 +209,7 @@ describe('StaggeredMotion', () => {
   // maybe shouldStopAnimation logic has a flaw
   it('should reach destination value', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <StaggeredMotion
@@ -222,8 +225,8 @@ describe('StaggeredMotion', () => {
             }}
           </StaggeredMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([[0, 10, 0, 10]]);
@@ -242,13 +245,17 @@ describe('StaggeredMotion', () => {
   it('should support jumping to value', () => {
     let count = [];
     let setState = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {p: false};
-      },
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
+          p: false,
+        };
+      }
       componentWillMount() {
         setState = this.setState.bind(this);
-      },
+      }
       render() {
         return (
           <StaggeredMotion styles={() => [{a: this.state.p ? 400 : spring(0)}]}>
@@ -258,8 +265,8 @@ describe('StaggeredMotion', () => {
             }}
           </StaggeredMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([0]);
@@ -291,13 +298,17 @@ describe('StaggeredMotion', () => {
   it('should behave well when many owner updates come in-between rAFs', () => {
     let count = [];
     let setState = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {a: spring(0)};
-      },
+    class App extends React.Component {
+      constructor(){
+        super();
+
+        this.state = {
+          a: spring(0),
+        };
+      }
       componentWillMount() {
         setState = this.setState.bind(this);
-      },
+      }
       render() {
         return (
           <StaggeredMotion styles={() => [this.state]}>
@@ -307,8 +318,8 @@ describe('StaggeredMotion', () => {
             }}
           </StaggeredMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([{a: 0}]);

--- a/test/StaggeredMotion-test.js
+++ b/test/StaggeredMotion-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import React from 'react';
 import {spring} from '../src/react-motion';
 import createMockRaf from './createMockRaf';
@@ -299,7 +300,7 @@ describe('StaggeredMotion', () => {
     let count = [];
     let setState = () => {};
     class App extends React.Component {
-      constructor(){
+      constructor() {
         super();
 
         this.state = {

--- a/test/TransitionMotion-test.js
+++ b/test/TransitionMotion-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable class-methods-use-this */
 import React from 'react';
 import {spring} from '../src/react-motion';
 import createMockRaf from './createMockRaf';
@@ -66,7 +67,7 @@ describe('TransitionMotion', () => {
       constructor() {
         super();
         this.state = {
-            kill: false,
+          kill: false,
         };
       }
       componentWillMount() {

--- a/test/TransitionMotion-test.js
+++ b/test/TransitionMotion-test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import {spring} from '../src/react-motion';
 import createMockRaf from './createMockRaf';
 import TestUtils from 'react-addons-test-utils';
@@ -19,25 +18,29 @@ describe('TransitionMotion', () => {
   });
 
   it('should allow returning null from children function', () => {
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         // shouldn't throw here
         return <TransitionMotion styles={[{key: '1', style: {}}]}>{() => null}</TransitionMotion>;
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
   });
 
   it('should not throw on unmount', () => {
     spyOn(console, 'error');
     let kill = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {kill: false};
-      },
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
+          kill: false,
+        };
+      }
       componentWillMount() {
         kill = () => this.setState({kill: true});
-      },
+      }
       render() {
         return this.state.kill
           ? null
@@ -46,8 +49,8 @@ describe('TransitionMotion', () => {
               styles={[{key: '1', style: {x: spring(10)}}]}>
               {() => null}
             </TransitionMotion>;
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
     mockRaf.step(2);
     kill();
@@ -59,13 +62,16 @@ describe('TransitionMotion', () => {
     // similar as above test
     spyOn(console, 'error');
     let kill = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {kill: false};
-      },
+    class App extends React.Component {
+      constructor() {
+        super();
+        this.state = {
+            kill: false,
+        };
+      }
       componentWillMount() {
         kill = () => this.setState({kill: true});
-      },
+      }
       render() {
         return this.state.kill
           ? null
@@ -74,8 +80,8 @@ describe('TransitionMotion', () => {
               styles={() => [{key: '1', style: {x: spring(10)}}]}>
               {() => null}
             </TransitionMotion>;
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
     mockRaf.step(2);
     kill();
@@ -85,7 +91,7 @@ describe('TransitionMotion', () => {
 
   it('should allow a defaultStyles', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <TransitionMotion
@@ -97,8 +103,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
 
     TestUtils.renderIntoDocument(<App />);
 
@@ -115,7 +121,7 @@ describe('TransitionMotion', () => {
 
   it('should accept different spring configs', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <TransitionMotion
@@ -129,8 +135,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     mockRaf.step(99);
@@ -149,7 +155,7 @@ describe('TransitionMotion', () => {
 
   it('should interpolate many values', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <TransitionMotion
@@ -167,8 +173,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
 
     TestUtils.renderIntoDocument(<App />);
 
@@ -204,15 +210,17 @@ describe('TransitionMotion', () => {
   it('should invoke didLeave in last frame', () => {
     let count = [];
     let setState = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
           val: [{key: '1', style: {x: spring(10)}}],
         };
-      },
+      }
       componentWillMount() {
         setState = this.setState.bind(this);
-      },
+      }
       render() {
         return (
           <TransitionMotion
@@ -225,8 +233,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([]);
@@ -241,7 +249,7 @@ describe('TransitionMotion', () => {
 
   it('should work with nested TransitionMotions', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <TransitionMotion
@@ -262,8 +270,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([
@@ -298,7 +306,7 @@ describe('TransitionMotion', () => {
 
   it('should reach destination value', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <TransitionMotion
@@ -310,8 +318,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([0]);
@@ -330,13 +338,17 @@ describe('TransitionMotion', () => {
   it('should support jumping to value', () => {
     let count = [];
     let setState = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {p: false};
-      },
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
+          p: false,
+        };
+      }
       componentWillMount() {
         setState = this.setState.bind(this);
-      },
+      }
       render() {
         return (
           <TransitionMotion
@@ -347,8 +359,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([{x: 0}]);
@@ -380,15 +392,17 @@ describe('TransitionMotion', () => {
   it('should behave well when many owner updates come in-between rAFs', () => {
     let count = [];
     let setState = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
           val: [{key: '1', style: {x: spring(0)}}],
         };
-      },
+      }
       componentWillMount() {
         setState = this.setState.bind(this);
-      },
+      }
       render() {
         return (
           <TransitionMotion
@@ -401,8 +415,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([[{key: '1', style: {x: 0}, data: undefined}]]);
@@ -457,15 +471,17 @@ describe('TransitionMotion', () => {
   it('should behave well when many owner styles function updates come in-between rAFs', () => {
     let count = [];
     let setState = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
           val: [{key: '1', style: {x: spring(0)}}],
         };
-      },
+      }
       componentWillMount() {
         setState = this.setState.bind(this);
-      },
+      }
       render() {
         return (
           <TransitionMotion
@@ -478,8 +494,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
     TestUtils.renderIntoDocument(<App />);
 
     expect(count).toEqual([[{key: '1', style: {x: 0}, data: undefined}]]);
@@ -533,7 +549,7 @@ describe('TransitionMotion', () => {
 
   it('should transition things in/out at the beginning', () => {
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <TransitionMotion
@@ -550,8 +566,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
 
     TestUtils.renderIntoDocument(<App />);
 
@@ -591,7 +607,7 @@ describe('TransitionMotion', () => {
   it('should eliminate things in/out at the beginning', () => {
     // similar to previous test, but without willEnter/leave
     let count = [];
-    const App = createReactClass({
+    class App extends React.Component {
       render() {
         return (
           <TransitionMotion
@@ -606,8 +622,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
 
     TestUtils.renderIntoDocument(<App />);
 
@@ -635,18 +651,20 @@ describe('TransitionMotion', () => {
   it('should carry around the ignored values', () => {
     let count = [];
     let setState = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
           val: [
             {key: '1', style: {a: spring(10), b: spring(410)}, data: [3]},
             {key: '3', style: {d: spring(10)}, data: [4]},
           ],
         };
-      },
+      }
       componentWillMount() {
         setState = this.setState.bind(this);
-      },
+      }
       render() {
         return (
           <TransitionMotion
@@ -663,8 +681,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
 
     TestUtils.renderIntoDocument(<App />);
 
@@ -739,18 +757,20 @@ describe('TransitionMotion', () => {
     let count = [];
     let prevValues = [];
     let setState = () => {};
-    const App = createReactClass({
-      getInitialState() {
-        return {
+    class App extends React.Component {
+      constructor() {
+        super();
+
+        this.state = {
           val: [
             {key: '1', style: {a: spring(10), b: spring(410)}, data: [3]},
             {key: '3', style: {d: spring(10)}, data: [4]},
           ],
         };
-      },
+      }
       componentWillMount() {
         setState = this.setState.bind(this);
-      },
+      }
       render() {
         return (
           <TransitionMotion
@@ -770,8 +790,8 @@ describe('TransitionMotion', () => {
             }}
           </TransitionMotion>
         );
-      },
-    });
+      }
+    }
 
     TestUtils.renderIntoDocument(<App />);
 


### PR DESCRIPTION
Fixes #461

CC: @nkbt 