### PR TITLE
Linebreak rule is missing in .eslintrc which causes webpack to fail on Windows...

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
     "prefer-const": 0,
     "no-multiple-empty-lines": 0,
     "no-useless-escape": 0,
-
+    "linebreak-style": 0,
     "react/no-did-mount-set-state": 2,
     "react/no-multi-comp": 0,
     "react/jsx-boolean-value": [2, "always"],


### PR DESCRIPTION
... simply adding the rule to the eslint config solves the problem.