### PR TITLE
Upgrade typings to flow 0.53.1

### DIFF
--- a/src/Motion.js
+++ b/src/Motion.js
@@ -5,10 +5,10 @@ import stepper from './stepper';
 import defaultNow from 'performance-now';
 import defaultRaf from 'raf';
 import shouldStopAnimation from './shouldStopAnimation';
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import type {ReactElement, PlainStyle, Style, Velocity, MotionProps} from './Types';
+import type {PlainStyle, Style, Velocity, MotionProps} from './Types';
 
 const msPerFrame = 1000 / 60;
 
@@ -230,7 +230,7 @@ export default class Motion extends React.Component<MotionProps, MotionState> {
     }
   }
 
-  render(): ReactElement {
+  render(): React.Node {
     const renderedChildren = this.props.children(this.state.currentStyle);
     return renderedChildren && React.Children.only(renderedChildren);
   }

--- a/src/StaggeredMotion.js
+++ b/src/StaggeredMotion.js
@@ -5,10 +5,10 @@ import stepper from './stepper';
 import defaultNow from 'performance-now';
 import defaultRaf from 'raf';
 import shouldStopAnimation from './shouldStopAnimation';
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import type {ReactElement, PlainStyle, Style, Velocity, StaggeredProps} from './Types';
+import type {PlainStyle, Style, Velocity, StaggeredProps} from './Types';
 
 const msPerFrame = 1000 / 60;
 
@@ -250,7 +250,7 @@ export default class StaggeredMotion extends React.Component<StaggeredProps, Sta
     }
   }
 
-  render(): ReactElement {
+  render(): React.Node {
     const renderedChildren = this.props.children(this.state.currentStyles);
     return renderedChildren && React.Children.only(renderedChildren);
   }

--- a/src/TransitionMotion.js
+++ b/src/TransitionMotion.js
@@ -6,11 +6,10 @@ import mergeDiff from './mergeDiff';
 import defaultNow from 'performance-now';
 import defaultRaf from 'raf';
 import shouldStopAnimation from './shouldStopAnimation';
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 
 import type {
-  ReactElement,
   PlainStyle,
   Velocity,
   TransitionStyle,
@@ -537,7 +536,7 @@ export default class TransitionMotion extends React.Component<TransitionProps, T
     }
   }
 
-  render(): ReactElement {
+  render(): React.Node {
     const hydratedStyles = rehydrateStyles(
       this.state.mergedPropsStyles,
       this.unreadPropStyles,

--- a/src/Types.js
+++ b/src/Types.js
@@ -4,8 +4,7 @@
 // Babel's sight.
 /* eslint-disable spaced-comment, no-undef */
 /*::
-import type {Element} from 'react';
-export type ReactElement = Element<*>;
+import * as React from 'react';
 */
 
 // === basic reused types ===
@@ -35,7 +34,7 @@ export type Velocity = {[key: string]: number};
 export type MotionProps = {
   defaultStyle?: PlainStyle,
   style: Style,
-  children: (interpolatedStyle: PlainStyle) => ReactElement,
+  children: (interpolatedStyle: PlainStyle) => React.Node,
   onRest?: () => void,
 };
 
@@ -43,7 +42,7 @@ export type MotionProps = {
 export type StaggeredProps = {
   defaultStyles?: Array<PlainStyle>,
   styles: (previousInterpolatedStyles: ?Array<PlainStyle>) => Array<Style>,
-  children: (interpolatedStyles: Array<PlainStyle>) => ReactElement,
+  children: (interpolatedStyles: Array<PlainStyle>) => React.Node,
 };
 
 // === TransitionMotion ===
@@ -65,7 +64,7 @@ export type DidLeave = (styleThatLeft: { key: string, data?: any }) => void;
 export type TransitionProps = {
   defaultStyles?: Array<TransitionPlainStyle>,
   styles: Array<TransitionStyle> | (previousInterpolatedStyles: ?Array<TransitionPlainStyle>) => Array<TransitionStyle>,
-  children: (interpolatedStyles: Array<TransitionPlainStyle>) => ReactElement,
+  children: (interpolatedStyles: Array<TransitionPlainStyle>) => React.Node,
   willEnter?: WillEnter,
   willLeave?: WillLeave,
   didLeave?: DidLeave


### PR DESCRIPTION
I simply ran the `flow-upgrade` command, and fixed the `ReactElement` types. I didn't change anything else, perhaps you'd like me to replace the `import  * as React` (which is what flow-upgrade does) by more granular imports?