### PR TITLE
Add check for undefined values in style object

### DIFF
--- a/src/shouldStopAnimation.js
+++ b/src/shouldStopAnimation.js
@@ -9,7 +9,7 @@ export default function shouldStopAnimation(
   currentVelocity: Velocity,
 ): boolean {
   for (let key in style) {
-    if (!Object.prototype.hasOwnProperty.call(style, key)) {
+    if (!Object.prototype.hasOwnProperty.call(style, key) || typeof style[key] === 'undefined') {
       continue;
     }
 


### PR DESCRIPTION
In our mocha unit tests react-motion caused errors such as:

```
  1)  Uncaught error outside test suite:
     Uncaught TypeError: Cannot read property 'val' of undefined
      at Object.shouldStopAnimation [as default] (node_modules/react-motion/lib/shouldStopAnimation.js:20:78)
      at Object.callback (node_modules/react-motion/lib/Motion.js:117:45)
      at Timeout._onTimeout (node_modules/raf/index.js:35:21)
```

This was caused by cases where the `style` object had undefined values, for example `{ height: undefined }`. Adding an extra guard to shouldStopAnimation seems to fix the issue.