### PR TITLE
Corrects React Element typings

### DIFF
--- a/src/Types.js
+++ b/src/Types.js
@@ -5,7 +5,9 @@
 /* eslint-disable spaced-comment, no-undef */
 /*::
 import type {Element} from 'react';
-export type ReactElement = Element<*>;
+// This is the typing of a single node (not an array)
+// https://flow.org/en/docs/react/types/#toc-react-node
+export type ReactElement = string | boolean | number | void | null | Element<*>;
 */
 
 // === basic reused types ===


### PR DESCRIPTION
We saw in #485 that it's not correct to use `React.Node` as the returned value of the `children` function, however, `Element<*>` is too [restrictive](https://github.com/chenglou/react-motion/pull/485#issuecomment-328120982), since it should be correct to return a string, null, or anything that can be rendered and that is not an Array. I used the [flow doc](https://flow.org/en/docs/react/types/#toc-react-node) as a reference, feel free to correct me if I'm wrong.