### PR TITLE
chenglou/react-motion#507 performance-now update

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "performance-now": "^0.2.0",
+    "performance-now": "^2.1.0",
     "prop-types": "^15.5.8",
     "raf": "^3.1.0"
   }


### PR DESCRIPTION
Update performance-now to ^2.1.0

> react-motion has a dependency of performance-now@^0.2.0
> 
> It also has a dependency on raf@^3.1.0 which currently resolves to raf@3.4.0
> 
> raf@3.40 has a dependency on performance-now@^2.1.0
> 
> This means that including react-motion as a dependency introduces 2 major versions of raf.

chenglou/react-motion#507 

