### PR TITLE
Convert TransitionMotion types to generic types

### DIFF
--- a/src/Types.js
+++ b/src/Types.js
@@ -23,10 +23,10 @@ export type OpaqueConfig = {
   precision: number,
 };
 // your typical style object given in props. Maps to a number or a spring config
-export type Style = {[key: string]: number | OpaqueConfig};
+export type Style = $Shape<{[key: string]: OpaqueConfig | number}>;
 // the interpolating style object, with the same keys as the above Style object,
 // with the values mapped to numbers, naturally
-export type PlainStyle = {[key: string]: number};
+export type PlainStyle = $Shape<{[key: string]: number}>;
 // internal velocity object. Similar to PlainStyle, but whose numbers represent
 // speed. Might be exposed one day.
 export type Velocity = {[key: string]: number};
@@ -47,26 +47,34 @@ export type StaggeredProps = {
 };
 
 // === TransitionMotion ===
-export type TransitionStyle = {
+export type TransitionStyle<T> = {
   key: string, // unique ID to identify component across render animations
-  data?: any, // optional data you want to carry along the style, e.g. itemText
+  data: T, // optional data you want to carry along the style, e.g. itemText
   style: Style, // actual style you're passing
-};
-export type TransitionPlainStyle = {
+}
+export type TransitionPlainStyle<T> = {
   key: string,
-  data?: any,
+  data: T,
   // same as TransitionStyle, passed as argument to style/children function
   style: PlainStyle,
-};
-export type WillEnter = (styleThatEntered: TransitionStyle) => PlainStyle;
-export type WillLeave = (styleThatLeft: TransitionStyle) => ?Style;
-export type DidLeave = (styleThatLeft: { key: string, data?: any }) => void;
+}
+export type WillEnter<T> = (styleThatEntered: TransitionStyle<T>) => PlainStyle;
+export type WillLeave<T> = (styleThatLeft: TransitionStyle<T>) => ?Style;
+export type DidLeave<T> = (styleThatLeft: { key: string, data: T }) => void;
 
-export type TransitionProps = {
-  defaultStyles?: Array<TransitionPlainStyle>,
-  styles: Array<TransitionStyle> | (previousInterpolatedStyles: ?Array<TransitionPlainStyle>) => Array<TransitionStyle>,
-  children: (interpolatedStyles: Array<TransitionPlainStyle>) => ReactElement,
-  willEnter?: WillEnter,
-  willLeave?: WillLeave,
-  didLeave?: DidLeave
+export type TransitionMotionProps<T> = {
+  defaultStyles?: Array<TransitionPlainStyle<T>>,
+  styles: Array<TransitionStyle<T>>| (previousInterpolatedStyles: ?Array<TransitionPlainStyle<T>>) => Array<TransitionStyle<T>>,
+  children: (interpolatedStyles: Array<TransitionPlainStyle<T>>) => ReactElement,
+  willEnter: WillEnter<T>,
+  willLeave: WillLeave<T>,
+  didLeave: DidLeave<T>
 };
+
+export type TransitionMotionDefaultProps<T> = {
+  willEnter: WillEnter<T>,
+  willLeave: WillLeave<T>,
+  didLeave: DidLeave<T>
+};
+
+export type TransitionProps<T> = $Shape<TransitionMotionProps<T>> & $Diff<TransitionProps<T>, TransitionMotionDefaultProps<T>>;

--- a/src/mergeDiff.js
+++ b/src/mergeDiff.js
@@ -17,11 +17,11 @@ import type {TransitionStyle} from './Types';
 // work well with js bc of the amount of allocation, and isn't optimized for our
 // current use-case bc the runtime is linear in terms of edges (see wiki for
 // meaning), which is huge when two lists have many common elements
-export default function mergeDiff(
-  prev: Array<TransitionStyle>,
-  next: Array<TransitionStyle>,
-  onRemove: (prevIndex: number, prevStyleCell: TransitionStyle) => ?TransitionStyle
-): Array<TransitionStyle> {
+export default function mergeDiff<T>(
+  prev: Array<TransitionStyle<T>>,
+  next: Array<TransitionStyle<T>>,
+  onRemove: (prevIndex: number, prevStyleCell: TransitionStyle<T>) => ?TransitionStyle<T>
+): Array<TransitionStyle<T>> {
   // bookkeeping for easier access of a key's index below. This is 2 allocations +
   // potentially triggering chrome hash map mode for objs (so it might be faster
   // to loop through and find a key's index each time), but I no longer care


### PR DESCRIPTION
Replace the use of `data: any` among the diferent `TransitionMotion` types with a generic type. This allows proper accurate typing between the different callback props and removes the dangerous behavior of casting any provided data value to `any`.

While change has no impact on any of the behavior of the `react-motion` (this PR only touches flow annotations), it could pose a small breaking change to consumers that are using flow as it will potentially uncover errors in their code.

The exported types are not directly backwards compatible, however updating application code to restore the previous type behavior is very simple. `TransitionMotion` will now infer the type of `data` from the provided props. To restore the original behavior, explicitly declare `data: any` in `styles` using either the exported types or manually;

**Using `TransitionStyle<>`:**
```jsx
// @flow
import TransitionMotion from 'react-motion/';
import type {TransitionStyle} from 'react-motion/lib/Types';

type Data = any;

class Example extends React.Component<{}> {
  render() {
    const styles: Array<TransitionStyle<Data>> = [...];
    return <TransitionMotion styles={styles} ... />;
  }
}
```

**Manual Types:**
```jsx
// @flow
import TransitionMotion from 'react-motion/';

type Data = any;

class Example extends React.Component<{}> {
  render() {
    const styles = [...].map((item: {data: Data}) => ({
      key: item.key,
      data: item.data,
      style: {...},
    }));

    return <TransitionMotion styles={styles} ... />;
  }
}
```