### PR TITLE
Replace deprecated componentWillReceiveProps with componentDidUpdate

### DIFF
--- a/src/Motion.js
+++ b/src/Motion.js
@@ -5,6 +5,7 @@ import stepper from './stepper';
 import defaultNow from 'performance-now';
 import defaultRaf from 'raf';
 import shouldStopAnimation from './shouldStopAnimation';
+import arePropsEqual from './arePropsEqual';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -210,13 +211,17 @@ export default class Motion extends React.Component<MotionProps, MotionState> {
     this.startAnimationIfNecessary();
   }
 
-  componentWillReceiveProps(props: MotionProps) {
+  componentDidUpdate(prevProps: MotionProps) {
+    if (arePropsEqual(prevProps, this.props)) {
+      return;
+    }
+
     if (this.unreadPropStyle != null) {
       // previous props haven't had the chance to be set yet; set them here
       this.clearUnreadPropStyle(this.unreadPropStyle);
     }
 
-    this.unreadPropStyle = props.style;
+    this.unreadPropStyle = this.props.style;
     if (this.animationID == null) {
       this.prevTime = defaultNow();
       this.startAnimationIfNecessary();

--- a/src/StaggeredMotion.js
+++ b/src/StaggeredMotion.js
@@ -5,6 +5,7 @@ import stepper from './stepper';
 import defaultNow from 'performance-now';
 import defaultRaf from 'raf';
 import shouldStopAnimation from './shouldStopAnimation';
+import arePropsEqual from './arePropsEqual';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -230,13 +231,17 @@ export default class StaggeredMotion extends React.Component<StaggeredProps, Sta
     this.startAnimationIfNecessary();
   }
 
-  componentWillReceiveProps(props: StaggeredProps) {
+  componentDidUpdate(prevProps: StaggeredProps) {
+    if (arePropsEqual(prevProps, this.props)) {
+      return;
+    }
+
     if (this.unreadPropStyles != null) {
       // previous props haven't had the chance to be set yet; set them here
       this.clearUnreadPropStyle(this.unreadPropStyles);
     }
 
-    this.unreadPropStyles = props.styles(this.state.lastIdealStyles);
+    this.unreadPropStyles = this.props.styles(this.state.lastIdealStyles);
     if (this.animationID == null) {
       this.prevTime = defaultNow();
       this.startAnimationIfNecessary();

--- a/src/arePropsEqual.js
+++ b/src/arePropsEqual.js
@@ -1,0 +1,16 @@
+function keysEqual(a, b): boolean {
+  let hasOwnProperty = Object.prototype.hasOwnProperty;
+  for (let k in a) {
+    if (hasOwnProperty.call(a, k)) {
+      if (!hasOwnProperty.call(b, k) || a[k] !== b[k]) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+export default function arePropsEqual(a: Object, b: Object): boolean {
+  return keysEqual(a, b) || keysEqual(b, a);
+}

--- a/test/Motion-test.js
+++ b/test/Motion-test.js
@@ -539,6 +539,7 @@ describe('Motion', () => {
     mockRaf.step(2);
     expect(count).toEqual([
       {a: 0},
+      {a: 0},
       {a: 0}, // this new 0 comes from owner update, causing Motion to re-render
       {a: 400},
       {a: 385.8333333333333},
@@ -548,9 +549,9 @@ describe('Motion', () => {
       {a: 350.02047519790233},
     ]);
     mockRaf.step(999);
-    expect(count.length).toBe(85);
+    expect(count.length).toBe(86);
     setState({a: spring(400)});
     // make sure we're still updating children even if there's nothing to interp
-    expect(count.length).toBe(86);
+    expect(count.length).toBe(87);
   });
 });

--- a/test/StaggeredMotion-test.js
+++ b/test/StaggeredMotion-test.js
@@ -331,6 +331,7 @@ describe('StaggeredMotion', () => {
     mockRaf.step(2);
     expect(count).toEqual([
       {a: 0},
+      {a: 0},
       {a: 0}, // this new 0 comes from owner update, causing StaggeredMotion to re-render
       {a: 400},
       {a: 385.8333333333333},
@@ -340,9 +341,9 @@ describe('StaggeredMotion', () => {
       {a: 350.02047519790233},
     ]);
     mockRaf.step(999);
-    expect(count.length).toBe(85);
+    expect(count.length).toBe(86);
     setState({a: spring(400)});
     // make sure we're still updating children even if there's nothing to interp
-    expect(count.length).toBe(86);
+    expect(count.length).toBe(87);
   });
 });


### PR DESCRIPTION
Context: [React v16.3 Component Lifecycle Changes](https://reactjs.org/blog/2018/03/29/react-v-16-3.html#component-lifecycle-changes).

Method `componentWillReceiveProps()` becomes deprecated since it doesn't guarantee the fact component _will_ receive props. In addition, it doesn't seem to be recommended to do any side-effects inside this method.

I attempted to switch to `componentDidMount()` since it seems to be the correct place for such updates and side-effects. I needed to add props check since the method is also called during state updates.

Since `componentDidMount()` is called a moment after `componentWillReceiveProps()`, another render happens between them with current (unchanged) state. This forced me to update a couple of tests with a component's state before actual animation restart. As for the user, it doesn't make any visible difference, since animation starts just a bit (a single event loop spin?) later.

I wanted to apply the same changes to `TransitionMotion` and it mostly worked. There were a couple of tests that I failed to understand and so update accordingly. At this moment, I'd like to get some feedback on the introduced changes and possibly some help moving forward. Thanks!

cc @chenglou @nkbt 