### PR TITLE
Export SpringHelperConfig type

### DIFF
--- a/src/react-motion.js
+++ b/src/react-motion.js
@@ -1,4 +1,7 @@
 /* @flow */
+
+export type { SpringHelperConfig } from './Types';
+
 export { default as Motion } from './Motion';
 export { default as StaggeredMotion } from './StaggeredMotion';
 export { default as TransitionMotion } from './TransitionMotion';


### PR DESCRIPTION
This type is used by [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd/blob/master/src/view/moveable/moveable.jsx#L3).

Flat bundles and single types reexport will forbid using internals so we
need to expose some types like this one. If something else will be
required we could make feature released after 0.6.