### PR TITLE
on first call initate the prevTime with currenttime

### DIFF
--- a/src/Motion.js
+++ b/src/Motion.js
@@ -44,7 +44,7 @@ export default class Motion extends React.Component<MotionProps, MotionState> {
   unmounting: boolean = false;
   wasAnimating: boolean = false;
   animationID: ?number = null;
-  prevTime: number = 0;
+  prevTime: ?number = null;
   accumulatedTime: number = 0;
 
   defaultState(): MotionState {
@@ -149,6 +149,9 @@ export default class Motion extends React.Component<MotionProps, MotionState> {
       this.wasAnimating = true;
 
       const currentTime = timestamp || defaultNow();
+      if (this.prevTime === null) {
+        this.prevTime = currentTime;
+      }
       const timeDelta = currentTime - this.prevTime;
       this.prevTime = currentTime;
       this.accumulatedTime = this.accumulatedTime + timeDelta;
@@ -239,7 +242,6 @@ export default class Motion extends React.Component<MotionProps, MotionState> {
   };
 
   componentDidMount() {
-    this.prevTime = defaultNow();
     this.startAnimationIfNecessary();
   }
 
@@ -251,7 +253,7 @@ export default class Motion extends React.Component<MotionProps, MotionState> {
 
     this.unreadPropStyle = props.style;
     if (this.animationID == null) {
-      this.prevTime = defaultNow();
+      this.prevTime = null;
       this.startAnimationIfNecessary();
     }
   }

--- a/src/StaggeredMotion.js
+++ b/src/StaggeredMotion.js
@@ -73,7 +73,7 @@ export default class StaggeredMotion extends React.Component<
 
   unmounting: boolean = false;
   animationID: ?number = null;
-  prevTime = 0;
+  prevTime: ?number = null;
   accumulatedTime = 0;
   // it's possible that currentStyle's value is stale: if props is immediately
   // changed from 0 to 400 to spring(0) again, the async currentStyle is still
@@ -167,6 +167,9 @@ export default class StaggeredMotion extends React.Component<
       }
 
       const currentTime = timestamp || defaultNow();
+      if (this.prevTime === null) {
+        this.prevTime = currentTime;
+      }
       const timeDelta = currentTime - this.prevTime;
       this.prevTime = currentTime;
       this.accumulatedTime = this.accumulatedTime + timeDelta;
@@ -272,7 +275,6 @@ export default class StaggeredMotion extends React.Component<
   };
 
   componentDidMount() {
-    this.prevTime = defaultNow();
     this.startAnimationIfNecessary();
   }
 
@@ -284,7 +286,7 @@ export default class StaggeredMotion extends React.Component<
 
     this.unreadPropStyles = props.styles(this.state.lastIdealStyles);
     if (this.animationID == null) {
-      this.prevTime = defaultNow();
+      this.prevTime = null;
       this.startAnimationIfNecessary();
     }
   }

--- a/src/TransitionMotion.js
+++ b/src/TransitionMotion.js
@@ -264,7 +264,7 @@ export default class TransitionMotion extends React.Component<
 
   unmounting: boolean = false;
   animationID: ?number = null;
-  prevTime = 0;
+  prevTime: ?number = null;
   accumulatedTime = 0;
   // it's possible that currentStyle's value is stale: if props is immediately
   // changed from 0 to 400 to spring(0) again, the async currentStyle is still
@@ -456,6 +456,9 @@ export default class TransitionMotion extends React.Component<
       }
 
       const currentTime = timestamp || defaultNow();
+      if (this.prevTime === null) {
+        this.prevTime = currentTime;
+      }
       const timeDelta = currentTime - this.prevTime;
       this.prevTime = currentTime;
       this.accumulatedTime = this.accumulatedTime + timeDelta;
@@ -572,7 +575,6 @@ export default class TransitionMotion extends React.Component<
   };
 
   componentDidMount() {
-    this.prevTime = defaultNow();
     this.startAnimationIfNecessary();
   }
 
@@ -596,7 +598,7 @@ export default class TransitionMotion extends React.Component<
     }
 
     if (this.animationID == null) {
-      this.prevTime = defaultNow();
+      this.prevTime = null;
       this.startAnimationIfNecessary();
     }
   }


### PR DESCRIPTION
The time returned by *performance-now*, which was used in `componentDidMount` and `componentWillReceiveProps` lifecycle functions to reset the animation, can be greater than the timestamp of `requestAnimationFrame` (*raf*) callback. Thus we got negative values for `timeDelta`. By initializing and resetting `prevTime` with null instead and setting it to to the timestamp of the first `requestAnimationFrame` callback, we can prevent negative values.