### PR TITLE
Bump Flow and use explicitly exact&inexact syntax for object types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -20,4 +20,8 @@
 
 [libs]
 
+[lints]
+ambiguous-object-type=error
+deprecated-type=error
+
 [options]

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-jsx-a11y": "^6.1.0",
     "eslint-plugin-react": "^7.10.0",
-    "flow-bin": "^0.53.1",
+    "flow-bin": "^0.119.1",
     "flow-copy-source": "^1.1.0",
     "husky": "^0.14.3",
     "inject-loader": "^4.0.1",

--- a/src/Motion.js
+++ b/src/Motion.js
@@ -18,12 +18,12 @@ import type {
 
 const msPerFrame = 1000 / 60;
 
-type MotionState = {
+type MotionState = {|
   currentStyle: PlainStyle,
   currentVelocity: Velocity,
   lastIdealStyle: PlainStyle,
   lastIdealVelocity: Velocity,
-};
+|};
 
 export default class Motion extends React.Component<MotionProps, MotionState> {
   static propTypes = {

--- a/src/StaggeredMotion.js
+++ b/src/StaggeredMotion.js
@@ -18,12 +18,12 @@ import type {
 
 const msPerFrame = 1000 / 60;
 
-type StaggeredMotionState = {
+type StaggeredMotionState = {|
   currentStyles: Array<PlainStyle>,
   currentVelocities: Array<Velocity>,
   lastIdealStyles: Array<PlainStyle>,
   lastIdealVelocities: Array<Velocity>,
-};
+|};
 
 function shouldStopAnimationAll(
   currentStyles: Array<PlainStyle>,

--- a/src/TransitionMotion.js
+++ b/src/TransitionMotion.js
@@ -201,13 +201,13 @@ function mergeAndSync(
   ];
 }
 
-type TransitionMotionDefaultProps = {
+type TransitionMotionDefaultProps = {|
   willEnter: WillEnter,
   willLeave: WillLeave,
   didLeave: DidLeave,
-};
+|};
 
-type TransitionMotionState = {
+type TransitionMotionState = {|
   // list of styles, each containing interpolating values. Part of what's passed
   // to children function. Notice that this is
   // Array<ActualInterpolatingStyleObject>, without the wrapper that is {key: ...,
@@ -222,7 +222,7 @@ type TransitionMotionState = {
   // the array that keeps track of currently rendered stuff! Including stuff
   // that you've unmounted but that's still animating. This is where it lives
   mergedPropsStyles: Array<TransitionStyle>,
-};
+|};
 
 export default class TransitionMotion extends React.Component<
   TransitionProps,

--- a/src/Types.js
+++ b/src/Types.js
@@ -5,7 +5,7 @@
 /* eslint-disable spaced-comment, no-undef */
 /*::
 import type {Element} from 'react';
-export type ReactElement = Element<*>;
+export type ReactElement = Element<any>;
 */
 
 // === basic reused types ===
@@ -14,6 +14,7 @@ export type SpringHelperConfig = {
   stiffness?: number,
   damping?: number,
   precision?: number,
+  ...
 };
 // the object returned by `spring(value, yourConfig)`. For internal usage only!
 export type OpaqueConfig = {
@@ -21,48 +22,55 @@ export type OpaqueConfig = {
   stiffness: number,
   damping: number,
   precision: number,
+  ...
 };
 // your typical style object given in props. Maps to a number or a spring config
-export type Style = { [key: string]: number | OpaqueConfig };
+export type Style = { [key: string]: number | OpaqueConfig, ... };
 // the interpolating style object, with the same keys as the above Style object,
 // with the values mapped to numbers, naturally
-export type PlainStyle = { [key: string]: number };
+export type PlainStyle = { [key: string]: number, ... };
 // internal velocity object. Similar to PlainStyle, but whose numbers represent
 // speed. Might be exposed one day.
-export type Velocity = { [key: string]: number };
+export type Velocity = { [key: string]: number, ... };
 
 // === Motion ===
-export type MotionProps = {
+export type MotionProps = {|
   defaultStyle?: PlainStyle,
   style: Style,
   children: (interpolatedStyle: PlainStyle) => ReactElement,
   onRest?: () => void,
-};
+|};
 
 // === StaggeredMotion ===
-export type StaggeredProps = {
+export type StaggeredProps = {|
   defaultStyles?: Array<PlainStyle>,
   styles: (previousInterpolatedStyles: ?Array<PlainStyle>) => Array<Style>,
   children: (interpolatedStyles: Array<PlainStyle>) => ReactElement,
-};
+|};
 
 // === TransitionMotion ===
 export type TransitionStyle = {
   key: string, // unique ID to identify component across render animations
   data?: any, // optional data you want to carry along the style, e.g. itemText
   style: Style, // actual style you're passing
+  ...
 };
 export type TransitionPlainStyle = {
   key: string,
   data?: any,
   // same as TransitionStyle, passed as argument to style/children function
   style: PlainStyle,
+  ...
 };
 export type WillEnter = (styleThatEntered: TransitionStyle) => PlainStyle;
 export type WillLeave = (styleThatLeft: TransitionStyle) => ?Style;
-export type DidLeave = (styleThatLeft: { key: string, data?: any }) => void;
+export type DidLeave = (styleThatLeft: {
+  key: string,
+  data?: any,
+  ...
+}) => void;
 
-export type TransitionProps = {
+export type TransitionProps = {|
   defaultStyles?: Array<TransitionPlainStyle>,
   styles:
     | Array<TransitionStyle>
@@ -73,4 +81,4 @@ export type TransitionProps = {
   willEnter?: WillEnter,
   willLeave?: WillLeave,
   didLeave?: DidLeave,
-};
+|};

--- a/src/mergeDiff.js
+++ b/src/mergeDiff.js
@@ -28,11 +28,11 @@ export default function mergeDiff(
   // bookkeeping for easier access of a key's index below. This is 2 allocations +
   // potentially triggering chrome hash map mode for objs (so it might be faster
   // to loop through and find a key's index each time), but I no longer care
-  let prevKeyIndex: { [key: string]: number } = {};
+  let prevKeyIndex: { [key: string]: number, ... } = {};
   for (let i = 0; i < prev.length; i++) {
     prevKeyIndex[prev[i].key] = i;
   }
-  let nextKeyIndex: { [key: string]: number } = {};
+  let nextKeyIndex: { [key: string]: number, ... } = {};
   for (let i = 0; i < next.length; i++) {
     nextKeyIndex[next[i].key] = i;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3817,9 +3817,10 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.53.1:
-  version "0.53.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.53.1.tgz#9b22b63a23c99763ae533ebbab07f88c88c97d84"
+flow-bin@^0.119.1:
+  version "0.119.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.119.1.tgz#b6d763b386ec9f1085848ca7df98909d80a16bd0"
+  integrity sha512-mX6qjJVi7aLqR9sDf8QIHt8yYEWQbkMLw7qFoC7sM/AbJwvqFm3pATPN96thsaL9o1rrshvxJpSgoj1PJSC3KA==
 
 flow-copy-source@^1.1.0:
   version "1.3.0"


### PR DESCRIPTION
Allows dependant code to turn on Flow option exact_by_default. (background info https://medium.com/flow-type/how-to-upgrade-to-exact-by-default-object-type-syntax-7aa44b4d08ab)